### PR TITLE
Slots should not have a Zip Deploy as a PostDeployTask

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -88,7 +88,8 @@ type SlotConfig =
             AppSettings = owner.AppSettings |> Option.map (Map.merge ( this.AppSettings |> Map.toList))
             ConnectionStrings = owner.ConnectionStrings |> Option.map (Map.merge (this.ConnectionStrings |> Map.toList))
             Identity = this.Identity + owner.Identity
-            KeyVaultReferenceIdentity = this.KeyVaultReferenceIdentity |> Option.orElse owner.KeyVaultReferenceIdentity}
+            KeyVaultReferenceIdentity = this.KeyVaultReferenceIdentity |> Option.orElse owner.KeyVaultReferenceIdentity
+            ZipDeployPath = None }
 
 type SlotBuilder() =
     member this.Yield _ =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -323,7 +323,9 @@ let tests = testList "Web App Tests" [
             |> getResource<Arm.Web.Site>
             |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
         // Default "production" slot is not included as it is created automatically in Azure
-        Expect.hasLength slots 1 "Should only be 1 slot"
+
+        Expect.hasLength slots 1 "Should only be 1 slot" 
+        Expect.isNone slots.[0].ZipDeployPath "ZipDeployPath should be set to None" 
     }
 
     test "WebApp with slot that has system assigned identity adds identity to slot" {

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -314,7 +314,7 @@ let tests = testList "Web App Tests" [
 
     test "WebApp supports adding slots" {
         let slot = appSlot { name "warm-up" }
-        let site:WebAppConfig = webApp { name "slots"; add_slot slot }
+        let site:WebAppConfig = webApp { name "slots"; add_slot slot; zip_deploy "test.zip" }
         Expect.isTrue (site.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
 
         let slots =
@@ -323,7 +323,6 @@ let tests = testList "Web App Tests" [
             |> getResource<Arm.Web.Site>
             |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
         // Default "production" slot is not included as it is created automatically in Azure
-
         Expect.hasLength slots 1 "Should only be 1 slot" 
         Expect.isNone slots.[0].ZipDeployPath "ZipDeployPath should be set to None" 
     }


### PR DESCRIPTION
The Site itself already has a `ZipDeployPath` leading to a `PostDeployTask` being run. When `ZipDeployPath` is set on a Slot a second deployment is attempted.
This second deployment which fails due to no `WebApp` with the name `{app_name}/{slot_name}` existing.

The changes in this PR are as follows:

* Set `ZipDeployPath` to `None` when creating a Site from a `SlotConfig`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Written unit tests** against the modified code that I have made.
