### PR TITLE
update cert dependancy to not need service plan Id

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -373,7 +373,7 @@ type Certificate =
                 {| certificates.Create(
                         this.ResourceName,
                         this.Location, 
-                        [this.SiteId; this.ServicePlanId; hostNameBindings.resourceId(this.SiteId.Name,ResourceName this.DomainName)]) with
+                        [this.SiteId; hostNameBindings.resourceId(this.SiteId.Name,ResourceName this.DomainName)]) with
                     properties =
                         {| serverFarmId = this.ServicePlanId.Eval()
                            canonicalName = this.DomainName |}


### PR DESCRIPTION
I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [✔] **Tested my code** end-to-end against a live Azure subscription.
* [✔] **Updated the documentation** in the docs folder for the affected changes.
* [✔] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
