### PR TITLE
allow slot_settings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 Release Notes
 =============
-## 1.6.22
+## vNext
 * WebApp/Functions: Support for deployment slot settings with `slot_setting` and `slot_settings`
 
 ## 1.6.21

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.6.22
+* WebApp/Functions: Support for deployment slot settings with `slot_setting` and `slot_settings`
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -45,6 +45,8 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | publish_as | Specifies whether to publish function as code or as a docker container. |
 | add_slot | Adds a deployment slot to the app |
 | add_slots | Adds multiple deployment slots to the app |
+| slot_setting | Sets a deployment slot setting of the function in the form "key" "value". |
+| slot_settings | Sets a list of deployment slot setting of the function as tuples in the form of ("key", "value"). |
 | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
 
 #### Post-deployment Builder Keywords

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -55,6 +55,8 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_private_endpoints | Adds private endpoints for this Webapp to the given subnets |
 | Web App | add_slot | Adds a deployment slot to the app |
 | Web App | add_slots | Adds multiple deployment slots to the app |
+| Web App | slot_setting | Sets a deployment slot setting of the web app in the form "key" "value". |
+| Web App | slot_settings | Sets a list of deployment slot setting of the web app as tuples in the form of ("key", "value"). |
 | Web App | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
 | Web App | custom_domain | Adds custom domain to the app, containing an app service managed certificate |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -9,7 +9,7 @@ open System
 
 let serverFarms = ResourceType ("Microsoft.Web/serverfarms", "2018-02-01")
 let sites = ResourceType ("Microsoft.Web/sites", "2020-06-01")
-let config = ResourceType ("Microsoft.Web/sites/config", "2016-08-01")
+let config = ResourceType ("Microsoft.Web/sites/config", "2020-06-01")
 let sourceControls = ResourceType ("Microsoft.Web/sites/sourcecontrols", "2019-08-01")
 let staticSites = ResourceType("Microsoft.Web/staticSites", "2019-12-01-preview")
 let siteExtensions = ResourceType("Microsoft.Web/sites/siteextensions", "2020-06-01")
@@ -391,6 +391,17 @@ type Certificate =
                         {| serverFarmId = this.ServicePlanId.Eval()
                            canonicalName = this.DomainName |}
                 |} :> _
+
+type SlotConfigName = 
+    { SiteName : ResourceName
+      SlotSettingNames: List<string> }
+    interface IArmResource with
+        member this.ResourceId = config.resourceId(this.SiteName/"slotconfignames")
+        member this.JsonModel =
+            {| config.Create(this.SiteName/"slotconfignames", dependsOn = [ sites.resourceId  this.SiteName]) with
+                kind = "string"
+                properties = {| appSettingNames = this.SlotSettingNames |}
+            |} :> _
 
 [<AutoOpen>]
 module SiteExtensions =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -394,7 +394,7 @@ type Certificate =
 
 type SlotConfigName = 
     { SiteName : ResourceName
-      SlotSettingNames: List<string> }
+      SlotSettingNames: string Set }
     interface IArmResource with
         member this.ResourceId = config.resourceId(this.SiteName/"slotconfignames")
         member this.JsonModel =

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -323,6 +323,12 @@ type FunctionsConfig =
                 { site with AppSettings = None; ConnectionStrings = None }
                 for (_, slot) in this.CommonWebConfig.Slots |> Map.toSeq do
                     slot.ToSite site
+                    
+            if this.CommonWebConfig.SlotSettingNames <> List.Empty then
+                {
+                    SiteName = this.Name.ResourceName;
+                    SlotSettingNames = this.CommonWebConfig.SlotSettingNames;
+                }
         ]
 
 type FunctionsBuilder() =
@@ -343,7 +349,8 @@ type FunctionsBuilder() =
               Slots = Map.empty
               WorkerProcess = None
               ZipDeployPath = None
-              HealthCheckPath = None }
+              HealthCheckPath = None
+              SlotSettingNames = List.Empty }
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -324,7 +324,7 @@ type FunctionsConfig =
                 for (_, slot) in this.CommonWebConfig.Slots |> Map.toSeq do
                     slot.ToSite site
                     
-            if this.CommonWebConfig.SlotSettingNames <> List.Empty then
+            if this.CommonWebConfig.SlotSettingNames <> Set.empty then
                 {
                     SiteName = this.Name.ResourceName;
                     SlotSettingNames = this.CommonWebConfig.SlotSettingNames;
@@ -350,7 +350,7 @@ type FunctionsBuilder() =
               WorkerProcess = None
               ZipDeployPath = None
               HealthCheckPath = None
-              SlotSettingNames = List.Empty }
+              SlotSettingNames = Set.empty }
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -179,7 +179,7 @@ type CommonWebConfig =
       WorkerProcess : Bitness option
       ZipDeployPath : (string*ZipDeploy.ZipDeploySlot) option
       HealthCheckPath: string option
-      SlotSettingNames: List<string> }
+      SlotSettingNames: string Set }
 
 type WebAppConfig =
     { CommonWebConfig: CommonWebConfig
@@ -522,7 +522,7 @@ type WebAppConfig =
                   SslState = SslDisabled }
             | NoDomain -> ()
             
-            if this.CommonWebConfig.SlotSettingNames <> List.Empty then
+            if this.CommonWebConfig.SlotSettingNames <> Set.empty then
                 {
                     SiteName = this.Name.ResourceName;
                     SlotSettingNames = this.CommonWebConfig.SlotSettingNames;
@@ -550,7 +550,7 @@ type WebAppBuilder() =
               WorkerProcess = None
               ZipDeployPath = None
               HealthCheckPath = None
-              SlotSettingNames = List.empty }
+              SlotSettingNames = Set.empty }
           Sku = Sku.F1
           WorkerSize = Small
           WorkerCount = 1
@@ -881,11 +881,11 @@ module Extensions =
         [<CustomOperation "slot_setting">]
         member this.AddSlotSetting (state:'T, key, value) =
             let current = this.Get state
-            { current with Settings = current.Settings.Add(key, LiteralSetting value); SlotSettingNames = List.append current.SlotSettingNames [key] }
+            { current with Settings = current.Settings.Add(key, LiteralSetting value); SlotSettingNames =current.SlotSettingNames.Add(key) }
             |> this.Wrap state
         [<CustomOperation "slot_settings">]
         member this.AddSlotSettings(state:'T, settings: (string*string) list) =
             let current = this.Get state
             settings
-            |> List.fold (fun (state:CommonWebConfig) (key, value: string) -> { state with Settings = state.Settings.Add(key, LiteralSetting value); SlotSettingNames = List.append state.SlotSettingNames [key] }) current
+            |> List.fold (fun (state:CommonWebConfig) (key, value: string) -> { state with Settings = state.Settings.Add(key, LiteralSetting value); SlotSettingNames = state.SlotSettingNames.Add(key) }) current
             |> this.Wrap state

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -388,10 +388,10 @@ let tests = testList "Functions tests" [
            
         let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
         Expect.containsAll  settings  expectedSettings "App settings should contain the slot settings"
-        Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"; "another_sticky_config"] "Slot config names should be set"
+        Expect.containsAll scn.SlotSettingNames ["sticky_config"; "another_sticky_config"] "Slot config names should be set"
         Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
-        Expect.sequenceEqual appSettingNames  [ "sticky_config"; "another_sticky_config"] "Slot config names should be present in template"
-        Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+        Expect.containsAll appSettingNames  [ "sticky_config"; "another_sticky_config"] "Slot config names should be present in template"
+        Expect.containsAll dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
 
     }
 
@@ -417,10 +417,10 @@ let tests = testList "Functions tests" [
              
         let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
         Expect.containsAll  settings  expectedSettings "App settings should contain the slot setting"
-        Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"] "Slot config name should be set"
+        Expect.containsAll scn.SlotSettingNames ["sticky_config"] "Slot config name should be set"
         Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
-        Expect.sequenceEqual appSettingNames  [ "sticky_config" ] "Slot config name should be present in template"
-        Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+        Expect.containsAll appSettingNames  [ "sticky_config" ] "Slot config name should be present in template"
+        Expect.containsAll dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
 
     }
 ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -364,4 +364,63 @@ let tests = testList "Functions tests" [
             |> Seq.map (fun x-> x.ToObject<{|name:string;value:string|}> ())
         Expect.contains appSettings {|name="APPINSIGHTS_INSTRUMENTATIONKEY"; value="[reference(resourceId('shared-group', 'Microsoft.Insights/components', 'theName'), '2014-04-01').InstrumentationKey]"|} "Invalid value for APPINSIGHTS_INSTRUMENTATIONKEY"
     }
+    
+    test "Supports slot settings" {
+        let functionsApp = functions { name "test"; slot_settings [ "sticky_config", "sticky_config_value"; "another_sticky_config", "another_sticky_config_value" ]} 
+
+        let scn = functionsApp |> getResources |> getResource<Web.SlotConfigName> |> List.head
+        let ws = functionsApp |> getResources |> getResource<Web.Site> |> List.head
+
+        let template = arm{ add_resource functionsApp}
+        let jobj = template.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
+
+        let appSettingNames = 
+            jobj.SelectTokens $"$..resources[?(@name=='{functionsApp.Name.ResourceName.Value}/slotconfignames')].properties.appSettingNames[*]" 
+            |> Seq.map (fun x -> x.ToString())
+
+        let dependencies = 
+            jobj.SelectTokens $"$..resources[?(@name=='{functionsApp.Name.ResourceName.Value}/slotconfignames')].dependsOn[*]" 
+            |> Seq.map (fun x -> x.ToString())
+
+        let expectedSettings = Map [ 
+            "sticky_config", LiteralSetting "sticky_config_value"
+            "another_sticky_config", LiteralSetting "another_sticky_config_value" ]
+           
+        let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
+        Expect.containsAll  settings  expectedSettings "App settings should contain the slot settings"
+        Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"; "another_sticky_config"] "Slot config names should be set"
+        Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
+        Expect.sequenceEqual appSettingNames  [ "sticky_config"; "another_sticky_config"] "Slot config names should be present in template"
+        Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+
+    }
+
+    test "Supports slot setting" {
+        let functionsApp = functions { name "test"; slot_setting "sticky_config" "sticky_config_value" } 
+
+        let scn = functionsApp |> getResources |> getResource<Web.SlotConfigName> |> List.head
+        let ws = functionsApp |> getResources |> getResource<Web.Site> |> List.head
+
+        let template = arm{ add_resource functionsApp}
+        let jobj = template.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
+
+        let appSettingNames = 
+            jobj.SelectTokens $"$..resources[?(@name=='{functionsApp.Name.ResourceName.Value}/slotconfignames')].properties.appSettingNames[*]" 
+            |> Seq.map (fun x -> x.ToString())
+
+        let dependencies = 
+            jobj.SelectTokens $"$..resources[?(@name=='{functionsApp.Name.ResourceName.Value}/slotconfignames')].dependsOn[*]" 
+            |> Seq.map (fun x -> x.ToString())
+
+        let expectedSettings = Map [ 
+            "sticky_config", LiteralSetting "sticky_config_value" ]
+             
+        let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
+        Expect.containsAll  settings  expectedSettings "App settings should contain the slot setting"
+        Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"] "Slot config name should be set"
+        Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
+        Expect.sequenceEqual appSettingNames  [ "sticky_config" ] "Slot config name should be present in template"
+        Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{functionsApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+
+    }
 ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -703,10 +703,10 @@ let tests = testList "Web App Tests" [
         
         let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
         Expect.containsAll  settings  expectedSettings "App settings should contain the slot settings"
-        Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"; "another_sticky_config"] "Slot config names should be set"
+        Expect.containsAll scn.SlotSettingNames ["sticky_config"; "another_sticky_config"] "Slot config names should be set"
         Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
-        Expect.sequenceEqual appSettingNames  [ "sticky_config"; "another_sticky_config"] "Slot config names should be present in template"
-        Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{webApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+        Expect.containsAll appSettingNames  [ "sticky_config"; "another_sticky_config"] "Slot config names should be present in template"
+        Expect.containsAll dependencies  [ $"[resourceId('Microsoft.Web/sites', '{webApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
 
     }
 
@@ -732,10 +732,10 @@ let tests = testList "Web App Tests" [
           
           let settings = Expect.wantSome ws.AppSettings "AppSettings should be set"
           Expect.containsAll  settings  expectedSettings "App settings should contain the slot setting"
-          Expect.sequenceEqual scn.SlotSettingNames ["sticky_config"] "Slot config name should be set"
+          Expect.containsAll scn.SlotSettingNames ["sticky_config"] "Slot config name should be set"
           Expect.equal scn.SiteName (ResourceName "test") "Parent name should be set"
-          Expect.sequenceEqual appSettingNames  [ "sticky_config" ] "Slot config name should be present in template"
-          Expect.sequenceEqual dependencies  [ $"[resourceId('Microsoft.Web/sites', '{webApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
+          Expect.containsAll appSettingNames  [ "sticky_config" ] "Slot config name should be present in template"
+          Expect.containsAll dependencies  [ $"[resourceId('Microsoft.Web/sites', '{webApp.Name.ResourceName.Value}')]"] "Slot config names resource should depend on web site"
 
       }
 ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

- Allows you to specify slot settings for web app/functions using `slot_setting `and `slot_settings`


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
