### PR TITLE
Codat add multiple custom domains

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,13 @@
 Release Notes
 =============
-## vNext
-* WebApp/Functions: Support for deployment slot settings with `slot_setting` and `slot_settings`
-
-## 1.6.23
-* WebApp: Create App-managed certificates in  the same resource group as the ASP to avoid ARM bug
+## 1.6.26
+* WebApp/Functions: Fix .NET on Linux deployments
 
 ## 1.6.25
-* WebApp/Functions: Fix autoSwapSlotName for app slots.
-* UserAssignedIdentities: added add_to_ad_group(s) operators for automatic AAD group membership
+* CosmosDb: Add support for serverless capacity mode.
+* WebApps/Functions: Fix autoSwapSlotName for app slots.
+* WebApps/Functions: Fix zip deployments for web app with slots.
+* WebApp: Create App-managed certificates in the same resource group as the ASP to avoid ARM bug
 
 ## 1.6.24
 * ContainerApps: Eagerly validate whether all containers in an app have a valid CPU/RAM combination.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,12 @@ stages:
     steps:
     - checkout: self
       submodules: 'true'
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core SDK'
+      inputs:
+        packageType: sdk
+        useGlobalJson: true
+        installationPath: $(Agent.ToolsDirectory)/dotnet
     - task: DotNetCoreCLI@2
       displayName: 'Restore'
       inputs:

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -22,7 +22,7 @@ The CosmosDB builder abstracts the idea of account and database into one. If you
 |-|-|-|
 | Database | name | Sets the name of the database. |
 | Database | link_to_account | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
-| Database | throughput | Sets the throughput of the account. |
+| Database | throughput | Sets the throughput with either "provisioned throughput" or "serverless". |
 | Database | add_containers | Adds a list of containers to the database. |
 | Account | account_name | Sets the name of the CosmosDB account. |
 | Account | api (not yet implemented) | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
@@ -50,7 +50,7 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    throughput 400<CosmosDb.RU>
+    throughput 400<RU> // or throughput Serverless
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
     add_containers [

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.0",
+    "version": "6.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Farmer/Arm/Alert.fs
+++ b/src/Farmer/Arm/Alert.fs
@@ -71,7 +71,7 @@ type MetricAlertCriteria =
 | SingleResourceMultipleMetricCriteria of Criterias : ResourceCriteria list
 | SingleResourceMultipleCustomMetricCriteria of Criterias : CustomMetricCriteria list
 /// If webtest is failing at the same time from x different locations
-| WebtestLocationAvailabilityCriteria of AiComponentId:Farmer.ResourceId * WebTestId:Farmer.ResourceId * FailedLocationCount:int 
+| WebtestLocationAvailabilityCriteria of AiComponentId:Farmer.ResourceId * WebTestId:Farmer.ResourceId * FailedLocationCount:int
 
 type AlertAction = {
     actionGroupId : string
@@ -97,7 +97,7 @@ let mapResourceCriteriaTimeAggregation (aggregation: MetricAggregation) =
 let createCriteria (criteria:MetricAlertCriteria) =
     match criteria with
     | MultipleResourceMultipleMetricCriteria (multicriteria:obj list) ->
-        {| allOf = multicriteria 
+        {| allOf = multicriteria
            ``odata.type`` = "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria" |} :> obj
     | SingleResourceMultipleMetricCriteria criterias ->
         {| allOf = criterias |> List.map(fun resourcecriteria ->
@@ -114,7 +114,7 @@ let createCriteria (criteria:MetricAlertCriteria) =
         {| allOf = criterias |> List.map(fun resourcecriteria ->
             {|  threshold = resourcecriteria.Threshold
                 name = "Metric1"
-                metricNamespace = resourcecriteria.MetricNamespace 
+                metricNamespace = resourcecriteria.MetricNamespace
                     |> Option.defaultValue (ResourceType("Azure.ApplicationInsights", ""))
                     |> (fun resourceType -> resourceType.Type)
                 metricName = resourcecriteria.MetricName |> (function | MetricsName n -> n)
@@ -167,7 +167,7 @@ type AlertData =
                        enabled = true
                        scopes = scopes
                        evaluationFrequency = this.Frequency |> (function | IsoDateTime x -> x)
-                       windowSize = this.Window|> (function | IsoDateTime x -> x) 
+                       windowSize = this.Window|> (function | IsoDateTime x -> x)
                        criteria = this.Criteria |> createCriteria
                        autoMitigate = true
                        targetResourceType =
@@ -176,4 +176,4 @@ type AlertData =
                            | _ -> null
                        actions = this.Actions
                    |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ApplicationGateway.fs
+++ b/src/Farmer/Arm/ApplicationGateway.fs
@@ -25,8 +25,8 @@ let applicationGatewayUrlPathMaps = ResourceType ("Microsoft.Network/application
 module private ResourceId =
     let asId (resourceId: ResourceId) =
         {| id = resourceId.Eval() |}
-    
-let private curry a b = a,b 
+
+let private curry a b = a,b
 
 type ApplicationGateway =
     { Name : ResourceName
@@ -39,7 +39,7 @@ type ApplicationGateway =
       AutoscaleConfiguration:
         {| MaxCapacity: int option
            MinCapacity: int |} option
-      FrontendPorts : 
+      FrontendPorts :
         {| Name : ResourceName
            Port : uint16 |} list
       FrontendIpConfigs :
@@ -83,7 +83,7 @@ type ApplicationGateway =
               Name : ResourceName
               FrontendIpConfiguration : ResourceName
               BackendAddressPool : ResourceName
-              CustomErrorConfigurations:  
+              CustomErrorConfigurations:
                 {| CustomErrorPageUrl: string
                    StatusCode: HttpStatusCode |} list
               FirewallPolicy : ResourceId option
@@ -120,7 +120,7 @@ type ApplicationGateway =
            TargetListener: ResourceName
            TargetUrl: string
            UrlPathMaps: ResourceName list |} list
-      RequestRoutingRules : 
+      RequestRoutingRules :
         {|  Name: ResourceName
             RuleType: RuleType
             HttpListener: ResourceName
@@ -131,13 +131,13 @@ type ApplicationGateway =
             UrlPathMap: ResourceName option
             Priority: int option
         |} list
-      RewriteRuleSets: 
+      RewriteRuleSets:
         {|  Name: ResourceName
             RewriteRules:
-              {| ActionSet: 
+              {| ActionSet:
                   {| RequestHeaderConfigurations:
                        {| HeaderName: string
-                          HeaderValue: string |} list 
+                          HeaderValue: string |} list
                      ResponseHeaderConfigurations:
                        {| HeaderName: string
                           HeaderValue: string |} list
@@ -151,8 +151,8 @@ type ApplicationGateway =
                      Pattern: string
                      Variable: string |} list
                  Name: string
-                 RuleSequence: int 
-             |} list 
+                 RuleSequence: int
+             |} list
          |} list
       SslCertificates:
         {| Name: ResourceName
@@ -167,9 +167,9 @@ type ApplicationGateway =
            PolicyType: PolicyType |} option
       SslProfiles:
           {| Name: ResourceName
-             ClientAuthConfiguration: 
+             ClientAuthConfiguration:
                {| VerifyClientCertIssuerDN: bool |}
-             SslPolicy: 
+             SslPolicy:
                {| CipherSuites: CipherSuite list
                   DisabledSslProtocols: SslProtocol list
                   MinProtocolVersion: SslProtocol
@@ -190,7 +190,7 @@ type ApplicationGateway =
              DefaultBackendHttpSettings: ResourceName
              DefaultRedirectConfiguration: ResourceName
              DefaultRewriteRuleSet: ResourceName
-             PathRules: 
+             PathRules:
               {|
                   Name: ResourceName
                   BackendAddressPool: ResourceName
@@ -239,7 +239,7 @@ type ApplicationGateway =
                                 capacity = this.Sku.Capacity |> Option.toNullable
                                 tier = this.Sku.Tier.ArmValue
                             |}
-                        autoscaleConfiguration = this.AutoscaleConfiguration |> Option.map (fun a -> 
+                        autoscaleConfiguration = this.AutoscaleConfiguration |> Option.map (fun a ->
                             {|
                                 maxCapacity = a.MaxCapacity
                                 minCapacity = a.MinCapacity
@@ -257,10 +257,10 @@ type ApplicationGateway =
                         backendHttpSettingsCollection = this.BackendHttpSettingsCollection |> List.map (fun settings ->
                             {|
                               name = settings.Name.Value
-                              properties = 
+                              properties =
                                 {|
                                     affinityCookieName = settings.AffinityCookieName |> Option.toObj
-                                    authenticationCertificates = 
+                                    authenticationCertificates =
                                         settings.AuthenticationCertificates
                                         |> List.map (curry this.Name >> applicationGatewayAuthenticationCertificates.resourceId >> ResourceId.asId)
                                     connectionDraining = settings.ConnectionDraining |> Option.map (fun drain ->
@@ -278,7 +278,7 @@ type ApplicationGateway =
                                     probeEnabled = settings.ProbeEnabled
                                     protocol = settings.Protocol.ArmValue
                                     requestTimeout = settings.RequestTimeoutInSeconds
-                                    trustedRootCertificates = 
+                                    trustedRootCertificates =
                                         settings.TrustedRootCertificates
                                         |> List.map (curry this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.asId)
                                 |}
@@ -296,21 +296,21 @@ type ApplicationGateway =
                         frontendPorts = this.FrontendPorts |> List.map (fun frontend ->
                             {|
                                 name = frontend.Name.Value
-                                properties = 
+                                properties =
                                     {| port = frontend.Port |}
                             |}
                         )
                         gatewayIPConfigurations = this.GatewayIPConfigurations |> List.map (fun gwip ->
                             {|
                                 name = gwip.Name.Value
-                                properties = 
+                                properties =
                                     {| subnet = gwip.Subnet |> Option.map ResourceId.asId |> Option.defaultValue Unchecked.defaultof<_> |}
                             |}
                         )
                         httpListeners = this.HttpListeners |> List.map (fun listener ->
                           {|
                             name = listener.Name.Value
-                            properties = 
+                            properties =
                                 {|
                                   customErrorConfigurations = listener.CustomErrorConfigurations |> List.map (fun cfg ->
                                     {|
@@ -368,7 +368,7 @@ type ApplicationGateway =
                         redirectConfigurations = this.RedirectConfigurations |> List.map (fun cfg ->
                             {|
                                 name = cfg.Name.Value
-                                properties = 
+                                properties =
                                     {|
                                         includePath = cfg.IncludePath
                                         includeQueryString = cfg.IncludeQueryString
@@ -384,7 +384,7 @@ type ApplicationGateway =
                         requestRoutingRules = this.RequestRoutingRules |> List.map (fun routingRule ->
                             {|
                                 name = routingRule.Name.Value
-                                properties = 
+                                properties =
                                     {|
                                         backendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,routingRule.BackendAddressPool) |> ResourceId.asId
                                         backendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,routingRule.BackendHttpSettings) |> ResourceId.asId
@@ -404,7 +404,7 @@ type ApplicationGateway =
                                 {|
                                     rewriteRules = ruleSet.RewriteRules |> List.map (fun rule ->
                                         {|
-                                            actionSet = 
+                                            actionSet =
                                                 {|  requestHeaderConfigurations = rule.ActionSet.RequestHeaderConfigurations |> List.map (fun cfg ->
                                                         {| headerName = cfg.HeaderName
                                                            headerValue = cfg.HeaderValue |}
@@ -413,7 +413,7 @@ type ApplicationGateway =
                                                         {| headerName = cfg.HeaderName
                                                            headerValue = cfg.HeaderValue |}
                                                     )
-                                                    urlConfiguration = 
+                                                    urlConfiguration =
                                                         {|
                                                           modifiedPath = rule.ActionSet.UrlConfiguration.ModifiedPath
                                                           modifiedQueryString = rule.ActionSet.UrlConfiguration.ModifiedQueryString
@@ -456,7 +456,7 @@ type ApplicationGateway =
                             |}
                         ) |> Option.defaultValue Unchecked.defaultof<_>
                         sslProfiles = this.SslProfiles |> List.map (fun sslProfile ->
-                            {| 
+                            {|
                               name = sslProfile.Name.Value
                               properties =
                                 {|
@@ -472,20 +472,20 @@ type ApplicationGateway =
                                       |}
                                   ) |> Option.defaultValue Unchecked.defaultof<_>
                                   trustedClientCertificates =
-                                    sslProfile.TrustedClientCertificates 
+                                    sslProfile.TrustedClientCertificates
                                     |> List.map (curry this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.asId)
                                 |}
                             |}
                         )
                         trustedClientCertificates = this.TrustedClientCertificates |> List.map (fun cert ->
                           {| name = cert.Name.Value
-                             properties = 
+                             properties =
                                 {| data = cert.Data |}
                           |}
                         )
                         trustedRootCertificates = this.TrustedRootCertificates |> List.map (fun cert ->
                           {| name = cert.Name.Value
-                             properties = 
+                             properties =
                                 {| data = cert.Data |> Option.toObj
                                    keyVaultSecretId = cert.KeyVaultSecretId |}
                           |}
@@ -543,4 +543,4 @@ type ApplicationGateway =
                         ) |> Option.defaultValue Unchecked.defaultof<_>
                     |}
                 zones = this.Zones |> List.map string
-            |} :> _
+            |}

--- a/src/Farmer/Arm/AvailabilityTest.fs
+++ b/src/Farmer/Arm/AvailabilityTest.fs
@@ -81,4 +81,4 @@ type AvailabilityTest =
                         Configuration =
                         {|  WebTest = System.Text.RegularExpressions.Regex.Replace(testString.Replace("\r\n","").Replace("\n",""), @"\s+", " ") |}
                     |}
-                |} :> _
+                |}

--- a/src/Farmer/Arm/AzureFirewall.fs
+++ b/src/Farmer/Arm/AzureFirewall.fs
@@ -50,5 +50,5 @@ type AzureFirewall =
                      virtualHub = this.VirtualHub |>  Option.map (fun resId -> box {| id = resId.ArmExpression.Eval() |}) |> Option.defaultValue null
                      firewallPolicy = this.FirewallPolicy |>  Option.map (fun resId -> box {| id = resId.ArmExpression.Eval() |}) |> Option.defaultValue null
                      hubIPAddresses = this.HubIPAddresses |> Option.map (fun x -> box x.JsonModel) |> Option.defaultValue null |}
-            |} :> _
+            |}
 

--- a/src/Farmer/Arm/Bastion.fs
+++ b/src/Farmer/Arm/Bastion.fs
@@ -32,4 +32,4 @@ type BastionHost =
                                    |}
                                |})
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/BingSearch.fs
+++ b/src/Farmer/Arm/BingSearch.fs
@@ -20,4 +20,4 @@ type Accounts =
                 sku = {| name = string this.Sku |}
                 kind = kind
                 properties = {| statisticsEnabled = this.Statistics.AsBoolean |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Cache.fs
+++ b/src/Farmer/Arm/Cache.fs
@@ -41,4 +41,4 @@ type Redis =
                            |> Option.toObj
                          redisConfiguration = this.RedisConfiguration
                      |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -273,7 +273,7 @@ module CdnRule =
                         .Add("headerName", modifyHeader.HttpHeaderName)
                         .Add ("value", modifyHeader.HttpHeaderValue))
 
-          
+
             match this with
             | CacheExpiration a ->
                 let armValue = a.CacheBehaviour.ArmValue
@@ -367,7 +367,7 @@ module Profiles =
                                                     order = rule.Order
                                                     conditions = rule.Conditions |> List.map (fun c -> c.JsonModel)
                                                     actions = rule.Actions |> List.map (fun a -> a.JsonModel) |}) |} |}
-                |} :> _
+                |}
 
     module Endpoints =
         type CustomDomain =
@@ -380,4 +380,4 @@ module Profiles =
                 member this.JsonModel =
                     {| customDomains.Create (this.Profile/this.Endpoint/this.Name, dependsOn = [ endpoints.resourceId(this.Profile, this.Endpoint) ]) with
                         properties = {| hostName = this.Hostname |}
-                    |} :> _
+                    |}

--- a/src/Farmer/Arm/CognitiveServices.fs
+++ b/src/Farmer/Arm/CognitiveServices.fs
@@ -18,4 +18,4 @@ type Accounts =
                 sku = {| name = string this.Sku |}
                 kind = this.Kind.ToString().Replace("_", ".")
                 properties = {||}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/CommunicationServices.fs
+++ b/src/Farmer/Arm/CommunicationServices.fs
@@ -15,4 +15,4 @@ type Resource =
         member this.JsonModel =
             {| resource.Create(this.Name, this.Location, tags = this.Tags) with
                 properties = {| dataLocation = this.DataLocation.ArmValue |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -45,8 +45,8 @@ type CustomScriptExtension =
                                 this.ScriptContents
                                 |> Encoding.UTF8.GetBytes
                                 |> Convert.ToBase64String |}
-                        |} :> _
-            |} :> _
+                        |}
+            |}
 
 type AadSshLoginExtension =
     { Location : Location
@@ -63,7 +63,7 @@ type AadSshLoginExtension =
                        typeHandlerVersion = "1.0"
                        autoUpgradeMinorVersion = true
                     |}
-            |} :> _
+            |}
 
 type VirtualMachine =
     { Name : ResourceName
@@ -161,4 +161,4 @@ type VirtualMachine =
                         | None ->
                             box {| bootDiagnostics = {| enabled = false |} |}
                 |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -16,7 +16,7 @@ type ContainerGroupIpAddress =
 
 type ContainerInstanceGpu =
     { Count: int
-      Sku: Gpu.Sku } 
+      Sku: Gpu.Sku }
     member internal this.JsonModel =
         {|
             count = this.Count
@@ -274,4 +274,4 @@ type ContainerGroup =
                                     |}
                           ]
                        |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ContainerRegistry.fs
+++ b/src/Farmer/Arm/ContainerRegistry.fs
@@ -18,4 +18,4 @@ type Registries =
             {| registries.Create(this.Name, this.Location, tags = this.Tags) with
                  sku = {| name = this.Sku.ToString() |}
                  properties = {| adminUserEnabled = this.AdminUserEnabled |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -169,7 +169,7 @@ type ManagedCluster =
                          |> Option.defaultValue []
                 ] |> Seq.concat |> Set.ofSeq |> Set.union this.Dependencies
             {| managedClusters.Create(this.Name, this.Location) with
-                   dependsOn = [ 
+                   dependsOn = [
                        dependencies |> Seq.map (fun r -> r.Eval())
                        this.DependencyExpressions |> Seq.map (fun r -> r.Eval())
                        ] |> Seq.concat
@@ -241,4 +241,4 @@ type ManagedCluster =
                                        adminPassword = winProfile.AdminPassword.ArmExpression.Eval() |}
                                 | None -> Unchecked.defaultof<_>
                        |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -31,7 +31,7 @@ module Servers =
             member this.JsonModel =
                 {|  databases.Create(this.Server/this.Name, dependsOn = [ servers.resourceId this.Server ]) with
                         properties = {|  charset = this.Charset; collation = this.Collation |}
-                |} :> _
+                |}
 
     type FirewallRule =
         { Name : ResourceName
@@ -44,7 +44,7 @@ module Servers =
             member this.JsonModel =
                 {| firewallRules.Create(this.Server/this.Name, this.Location, [ servers.resourceId this.Server ]) with
                     properties = {| startIpAddress = string this.Start; endIpAddress = string this.End; |}
-                |} :> _
+                |}
 
 type Server =
     { Name : ResourceName
@@ -96,4 +96,4 @@ type Server =
             {| servers.Create(this.Name, this.Location, tags = (this.Tags |> Map.add "displayName" this.Name.Value)) with
                     sku = this.Sku
                     properties = this.GetProperties()
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Dashboard.fs
+++ b/src/Farmer/Arm/Dashboard.fs
@@ -9,7 +9,7 @@ let dashboard = ResourceType("Microsoft.Portal/dashboards", "2020-09-01-preview"
 type DashboardMetadata =
 | EmptyMetadata
 | CustomMetadata of obj
-| Cache24h 
+| Cache24h
 
 type LensAsset = { idInputName : string;  ``type`` : string }
 type LensMetadata = {
@@ -35,7 +35,7 @@ let generateMarkdownPart (markdownProperties:MarkdownPartParameters) = {
     inputs = List.empty
     settings = {| content = markdownProperties.content; title = markdownProperties.title; subtitle = markdownProperties.subtitle |} :> obj
     filters = null
-    asset = Unchecked.defaultof<LensAsset> 
+    asset = Unchecked.defaultof<LensAsset>
     isAdapter = System.Nullable()
     defaultMenuItemId = null
 }
@@ -47,7 +47,7 @@ let generateVideoPart (videoProperties:VideoPartParameters) = {
     inputs = List.empty
     settings = {| content = {| settings = {| title = videoProperties.title; subtitle = videoProperties.subtitle; src = videoProperties.url; autoplay= false |} |} |} :> obj
     filters = null
-    asset = Unchecked.defaultof<LensAsset> 
+    asset = Unchecked.defaultof<LensAsset>
     isAdapter = System.Nullable()
     defaultMenuItemId = null
 }
@@ -81,7 +81,7 @@ let generateMetricsChartPart (chartProperties:MetrixChartParameters) = {
                   value = {| id = chartProperties.resourceId.ArmExpression.Eval(); chartType = 0;
                              timespan = {| duration = match chartProperties.interval with | IsoDateTime dur -> dur
                                            start = null; ``end`` = null |}
-                             metrics = chartProperties.metrics |> List.map(function 
+                             metrics = chartProperties.metrics |> List.map(function
                                             MetricsName m -> {| name = m; resourceId = chartProperties.resourceId.ArmExpression.Eval() |})
                           |} |}  ]
     settings = null
@@ -117,7 +117,7 @@ type Dashboard =
         member this.ResourceId = dashboard.resourceId this.Name
         member this.JsonModel =
 
-            let dahsboardTitle = 
+            let dahsboardTitle =
                 match this.Title with
                 | Some title -> title
                 | None -> this.Name.Value
@@ -132,7 +132,7 @@ type Dashboard =
                             match this.Metadata with
                             | EmptyMetadata -> {||} :> obj
                             | CustomMetadata metad -> metad
-                            | Cache24h -> 
+                            | Cache24h ->
                                 {| model =
                                     {| timeRange =
                                          {| ``type`` = "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"; value = {| relative = {| duration = 24; timeUnit = 1 |} |} |}
@@ -142,7 +142,7 @@ type Dashboard =
                                                                                   displayCache = {| name = "UTC Time"; value = "Past 24 hours" |}
                                            |} |} |}
                                     |}
-                                |} :> _
+                                |}
                           lenses = [ {| order = "0"; parts = this.LensParts |} ]
                        |}
-                |} :> _
+                |}

--- a/src/Farmer/Arm/DataLakeStore.fs
+++ b/src/Farmer/Arm/DataLakeStore.fs
@@ -19,4 +19,4 @@ type Account =
                  properties =
                   {| newTier = this.Sku.ToString()
                      encryptionState = this.EncryptionState.ToString() |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Databricks.fs
+++ b/src/Farmer/Arm/Databricks.fs
@@ -67,4 +67,4 @@ type Workspace =
                             ()
                         ]
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/DeploymentScript.fs
+++ b/src/Farmer/Arm/DeploymentScript.fs
@@ -95,4 +95,4 @@ type DeploymentScript =
                         this.Timeout
                         |> Option.map Xml.XmlConvert.ToString
                         |> Option.toObj |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Devices.fs
+++ b/src/Farmer/Arm/Devices.fs
@@ -76,7 +76,7 @@ type iotHubs =
                    sku =
                     {| name = this.Sku.Name
                        capacity = this.Sku.Capacity |}
-            |} :> _
+            |}
 
 type ProvisioningServices =
     { Name : ResourceName
@@ -101,4 +101,4 @@ type ProvisioningServices =
                               name = this.IotHubPath |}
                        ]
                      |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/DiagnosticSetting.fs
+++ b/src/Farmer/Arm/DiagnosticSetting.fs
@@ -64,4 +64,4 @@ type DiagnosticSettings =
                         this.Sinks.LogAnalyticsWorkspace
                         |> Option.map (fun (resource,_) -> resource.Eval())
                         |> Option.toObj |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -38,10 +38,10 @@ type DnsZone =
         member this.JsonModel =
             {| zones.Create(this.Name, Location.Global, this.Dependencies) with
                 properties = {| zoneType = this.Properties.ZoneType |}
-            |} :> _
+            |}
 
 module DnsRecords =
-    let private sourceZoneNSRecordReference (zoneResourceId:ResourceId) : ArmExpression = 
+    let private sourceZoneNSRecordReference (zoneResourceId:ResourceId) : ArmExpression =
         let sourceZoneResId =
             { zoneResourceId with
                 Segments = [ ResourceName "@" ]
@@ -50,7 +50,7 @@ module DnsRecords =
             .reference(nsRecord, sourceZoneResId)
             .Map(fun r -> r + ".NSRecords")
             .WithOwner(sourceZoneResId)
-        
+
 
     type DnsRecord =
         { Name : ResourceName
@@ -88,17 +88,17 @@ module DnsRecords =
                         | PTR records -> "PTRRecords", records |> List.map (fun ptr -> {| ptrdname = ptr |}) |> box
                         | A (_, records) -> "ARecords", records |> List.map (fun a -> {| ipv4Address = a |}) |> box
                         | AAAA (_, records) -> "AAAARecords", records |> List.map (fun aaaa -> {| ipv6Address = aaaa |}) |> box
-                        | SRV records -> 
-                            let records = 
-                                records 
+                        | SRV records ->
+                            let records =
+                                records
                                 |> List.map (fun srv ->
                                     {| priority = srv.Priority |> Option.toNullable
                                        weight = srv.Weight |> Option.toNullable
                                        port = srv.Port |> Option.toNullable
                                        target =  Option.toObj srv.Target |})
                             "SRVRecords", box records
-                        | SOA record -> 
-                            let record = 
+                        | SOA record ->
+                            let record =
                                 {| host = Option.toObj record.Host
                                    email = Option.toObj record.Email
                                    serialNumber = record.SerialNumber |> Option.toNullable
@@ -109,4 +109,4 @@ module DnsRecords =
                             "SOARecord", box record
                         | CName (_, None) -> ()
                     ] |> Map
-                |} :> _
+                |}

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -4,10 +4,10 @@ module Farmer.Arm.DocumentDb
 open Farmer
 open Farmer.CosmosDb
 
-let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-01-15")
-let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-01-15")
-let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-01-15")
-let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-01-15")
+let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-04-15")
+let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-04-15")
+let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-04-15")
+let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-04-15")
 
 type DatabaseKind =
     | Document
@@ -65,12 +65,12 @@ module DatabaseAccounts =
                                        |}
                                    |}
                                |}
-                    |} :> _
+                    |}
 
     type SqlDatabase =
         { Name : ResourceName
           Account : ResourceName
-          Throughput : int<RU>
+          Throughput : Throughput
           Kind: DatabaseKind }
         interface IArmResource with
             member this.ResourceId = sqlDatabases.resourceId (this.Account/this.Name)
@@ -82,8 +82,13 @@ module DatabaseAccounts =
                 {| resource.Create(this.Account/this.Name, dependsOn = [ databaseAccounts.resourceId this.Account ]) with
                        properties =
                            {| resource = {| id = this.Name.Value |}
-                              options = {| throughput = string this.Throughput |} |}
-                |} :> _
+                              options =
+                                  {| throughput =
+                                      match this.Throughput with
+                                      | Provisioned t -> string t
+                                      | Serverless -> null |} 
+                           |}
+                |}
 
 type DatabaseAccount =
     { Name : ResourceName
@@ -92,6 +97,7 @@ type DatabaseAccount =
       FailoverPolicy : FailoverPolicy
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
+      Serverless : FeatureFlag
       Kind : DatabaseKind
       Tags: Map<string,string>  }
     member this.MaxStatelessPrefix =
@@ -139,12 +145,16 @@ type DatabaseAccount =
                             |}
                           databaseAccountOfferType = "Standard"
                           enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
-                          autoenableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
+                          enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
-                            match this.FailoverLocations with
-                            | [] -> null
-                            | locations -> box locations
+                            match this.FailoverLocations, this.Serverless with
+                            | [], Enabled -> box [ {| locationName = this.Location.ArmValue |} ]
+                            | [], Disabled -> null
+                            | locations, _ -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess
                           enableFreeTier = this.FreeTier
+                          capabilities =
+                            if this.Serverless = Enabled then box [ {| name = "EnableServerless" |} ]
+                            else null
                        |} |> box
-            |} :> _
+            |}

--- a/src/Farmer/Arm/EventGrid.fs
+++ b/src/Farmer/Arm/EventGrid.fs
@@ -54,7 +54,7 @@ type Topic =
                 properties =
                     {| source = sourceResourceId.Eval()
                        topicType = this.TopicType.Value |}
-             |} :> _
+             |}
 
 type Subscription<'T> =
     { Name : ResourceName
@@ -84,25 +84,25 @@ type Subscription<'T> =
                           | EventHub hubName ->
                             {| endpointType = "EventHub"
                                properties = {| resourceId = Namespaces.eventHubs.resourceId(this.Destination, hubName).Eval() |}
-                            |} :> _
+                            |}
                           | StorageQueue queueName ->
                             {| endpointType = "StorageQueue"
                                properties =
                                 {| resourceId = (storageAccounts.resourceId this.Destination).Eval()
                                    queueName = queueName.Value |}
-                            |} :> _
+                            |}
                           | ServiceBus (Queue { Queue = queue; Bus = bus}) ->
                             {| endpointType = "ServiceBusQueue"
                                properties =
                                 {| resourceId = (ServiceBus.queues.resourceId (bus, queue)).Eval()
                                    queueName = queue.Value |}
-                            |} :> _
+                            |}
                           | ServiceBus (Topic { Topic = topic; Bus = bus}) ->
                             {| endpointType = "ServiceBusTopic"
                                properties =
                                 {| resourceId = (ServiceBus.topics.resourceId (bus, topic)).Eval()
                                    queueName = topic.Value |}
-                            |} :> _
+                            |}
                       filter = {| includedEventTypes = [ for event in this.Events do event.Value ] |}
                    |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -38,7 +38,7 @@ type Namespace =
                              | ManualInflate -> false)
                          |> Option.toNullable
                         maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable |}
-            |} :> _
+            |}
 module Namespaces =
     let eventHubs = ResourceType ("Microsoft.EventHub/namespaces/eventhubs", "2017-04-01")
     let authorizationRules = ResourceType ("Microsoft.EventHub/namespaces/AuthorizationRules", "2017-04-01")
@@ -74,7 +74,7 @@ module Namespaces =
                             | None ->
                                 null
                         |}
-               |} :> _
+               |}
     module EventHubs =
         let authorizationRules = ResourceType ("Microsoft.EventHub/namespaces/eventhubs/AuthorizationRules", "2017-04-01")
         let consumerGroups = ResourceType ("Microsoft.EventHub/namespaces/eventhubs/consumergroups", "2017-04-01")
@@ -85,7 +85,7 @@ module Namespaces =
               Dependencies : ResourceId list }
             interface IArmResource with
                 member this.ResourceId = consumerGroups.resourceId (this.EventHub/this.ConsumerGroupName)
-                member this.JsonModel = consumerGroups.Create(this.EventHub/this.ConsumerGroupName, this.Location, this.Dependencies) :> _
+                member this.JsonModel = consumerGroups.Create(this.EventHub/this.ConsumerGroupName, this.Location, this.Dependencies)
 
         type AuthorizationRule =
             { Name : ResourceName
@@ -97,4 +97,4 @@ module Namespaces =
                 member this.JsonModel =
                     {| authorizationRules.Create(this.Name, this.Location, this.Dependencies) with
                         properties = {| rights = this.Rights |> Set.map string |> Set.toList |}
-                    |} :> _
+                    |}

--- a/src/Farmer/Arm/Insights.fs
+++ b/src/Farmer/Arm/Insights.fs
@@ -31,4 +31,4 @@ type Components =
                        | None -> null
                      DisableIpMasking = this.DisableIpMasking
                      SamplingPercentage = this.SamplingPercentage |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -41,7 +41,7 @@ module Vaults =
                                exp = this.ExpirationDate |> Option.map Secret.TotalSecondsSince1970 |> Option.toNullable
                             |}
                         |}
-                |} :> _
+                |}
     let private armValue armValue (a: 'a option) =
       a |> Option.map armValue |> Option.defaultValue Unchecked.defaultof<_>
     type Key =
@@ -79,7 +79,7 @@ module Vaults =
                             | RSA (RsaKeyLength keySize) -> box keySize
                             | RSAHSM (RsaKeyLength keySize) -> box keySize
                             | _ -> null |}
-              |} :> _
+              |}
 
 type CreateMode = Recover | Default
 type Vault =
@@ -159,7 +159,7 @@ type Vault =
                            ipRules = this.IpRules
                            virtualNetworkRules = this.VnetRules |> List.map (fun rule -> {| id = rule |}) |}
                     |}
-            |} :> _
+            |}
 
 type VaultAddPolicies =
     { KeyVault : LinkedResource
@@ -197,4 +197,4 @@ type VaultAddPolicies =
                             |}
                        |]
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/LoadBalancer.fs
+++ b/src/Farmer/Arm/LoadBalancer.fs
@@ -118,7 +118,7 @@ type LoadBalancer =
                         outboundNatRules = []
                         inboundNatPools = []
                     |}
-            |} :> _
+            |}
 type BackendAddressPool =
     {   /// Name of the backend address pool
         Name : ResourceName
@@ -161,4 +161,4 @@ type BackendAddressPool =
                             |}
                         )
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/LogAnalytics.fs
+++ b/src/Farmer/Arm/LogAnalytics.fs
@@ -29,7 +29,7 @@ type Workspace =
                         this.IngestionSupport |> Option.map(fun f -> f.ArmValue) |> Option.toObj
                        publicNetworkAccessForQuery =
                         this.QuerySupport |> Option.map(fun f -> f.ArmValue) |> Option.toObj |}
-            |} :> _
+            |}
 
 type LogAnalytics =
     static member getCustomerId resourceId =

--- a/src/Farmer/Arm/ManagedIdentity.fs
+++ b/src/Farmer/Arm/ManagedIdentity.fs
@@ -16,7 +16,7 @@ type UserAssignedIdentity =
 
     interface IArmResource with
         member this.ResourceId = userAssignedIdentities.resourceId this.Name
-        member this.JsonModel = userAssignedIdentities.Create(this.Name, this.Location, [], this.Tags) :> _
+        member this.JsonModel = userAssignedIdentities.Create(this.Name, this.Location, [], this.Tags)
     interface IPostDeploy with
         member this.Run rg = 
             if this.ActiveDirectoryGroups.IsEmpty 

--- a/src/Farmer/Arm/Maps.fs
+++ b/src/Farmer/Arm/Maps.fs
@@ -20,4 +20,4 @@ type Maps =
                         match this.Sku with
                         | S0 -> "S0"
                         | S1 -> "S1" |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -38,7 +38,7 @@ type PublicIpAddress =
                         match this.DomainNameLabel with
                         | Some label -> box {| domainNameLabel = label.ToLower() |}
                         | None -> null |}
-            |} :> _
+            |}
 
 type SubnetDelegation =
     { Name : ResourceName
@@ -88,10 +88,10 @@ type Subnet =
             match this.VirtualNetwork with
             | Some (Managed vnet) ->
                 {| subnets.Create(vnet.Name / this.Name, dependsOn=[vnet]) with
-                    properties = this.JsonModelProperties |} :> _
+                    properties = this.JsonModelProperties |}
             | Some (Unmanaged vnet) ->
                 {| subnets.Create(vnet.Name / this.Name) with
-                    properties = this.JsonModelProperties |} :> _
+                    properties = this.JsonModelProperties |}
             | None -> raiseFarmer "Subnet record must be linked to a virtual network to properly assign the resourceId."
         member this.ResourceId =
             match this.VirtualNetwork with
@@ -124,7 +124,7 @@ type VirtualNetwork =
                            |> List.map(fun subnet ->
                                {| name = subnet.Name.Value; properties = subnet.JsonModelProperties |})
                     |}
-            |} :> _
+            |}
 
 type VPNClientProtocol =
     | IkeV2
@@ -224,7 +224,7 @@ type VirtualNetworkGateway =
                             | None -> null
                         activeActive = this.IpConfigs |> List.length > 1
                      |}
-            |} :> _
+            |}
 
 type Connection =
     { Name : ResourceName
@@ -264,7 +264,7 @@ type Connection =
                             | Some peerId -> box {| id = peerId |}
                             | None -> null
                      |}
-            |} :> _
+            |}
 
 type NetworkInterface =
     { Name : ResourceName
@@ -312,11 +312,11 @@ type NetworkInterface =
             | None ->
                 {| networkInterfaces.Create(this.Name, this.Location, dependsOn, this.Tags) with
                     properties = props
-                |} :> _
+                |}
             | Some nsg ->
                 {| networkInterfaces.Create(this.Name, this.Location, dependsOn, this.Tags) with
                     properties = {| props with networkSecurityGroup = {| id = nsg.Eval() |} |}
-                |} :> _
+                |}
 
 
 type NetworkProfile =
@@ -354,7 +354,7 @@ type NetworkProfile =
                             |}
                         )
                     |}
-            |} :> _
+            |}
 
 type ExpressRouteCircuit =
     { Name : ResourceName
@@ -403,7 +403,7 @@ type ExpressRouteCircuit =
                            peeringLocation = this.PeeringLocation
                            bandwidthInMbps = this.Bandwidth |}
                        globalReachEnabled = this.GlobalReachEnabled |}
-            |} :> _
+            |}
 
 type ExpressRouteCircuitAuthorization =
     { Name : ResourceName
@@ -414,7 +414,7 @@ type ExpressRouteCircuitAuthorization =
             expressRouteCircuitAuthorizations.Create(
                 this.Circuit.Name / this.Name,
                 dependsOn=[this.Circuit.ResourceId])
-            :> _
+
 
 type PrivateEndpoint =
   { Name: ResourceName
@@ -448,7 +448,7 @@ type PrivateEndpoint =
                     |}
                   ]
              |}
-      |} :> _
+      |}
 
 type GatewayTransit =
     | UseRemoteGateway
@@ -486,4 +486,4 @@ type NetworkPeering =
                        useRemoteGateways = match this.GatewayTransit with | UseRemoteGateway -> true | _ -> false
                        remoteVirtualNetwork = {| id = match this.RemoteVNet with | Managed id | Unmanaged id -> id.ArmExpression.Eval() |}
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -73,7 +73,7 @@ type SecurityRule =
             let dependsOn = [ networkSecurityGroups.resourceId this.SecurityGroup ]
             {| securityRules.Create(this.SecurityGroup/this.Name, dependsOn = dependsOn) with
                 properties = this.PropertiesModel
-            |} :> _
+            |}
 
 type NetworkSecurityGroup =
     { Name : ResourceName
@@ -82,14 +82,14 @@ type NetworkSecurityGroup =
       Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceId = networkSecurityGroups.resourceId this.Name
-        member this.JsonModel = 
+        member this.JsonModel =
             {| networkSecurityGroups.Create(this.Name, this.Location, tags = this.Tags) with
                 properties =
-                    {| securityRules = 
+                    {| securityRules =
                         this.SecurityRules |> List.map (fun rule ->
                             {| name = rule.Name.Value
                                ``type`` = securityRules.Type
                                properties = rule.PropertiesModel
                             |} )
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ResourceGroup.fs
+++ b/src/Farmer/Arm/ResourceGroup.fs
@@ -53,12 +53,12 @@ type ResourceGroupDeployment =
                 | :? IParameters as p -> yield! p.SecureParameters
                 | _ -> ()
           ] |> List.distinct
-    member this.RequiredResourceGroups: string list = 
-        let nestedRgs = 
-            this.Resources 
-            |> List.collect 
-                (function 
-                | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups 
+    member this.RequiredResourceGroups =
+        let nestedRgs =
+            this.Resources
+            |> List.collect
+                (function
+                | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups
                 | _ ->  [])
         if this.TargetResourceGroup.Value.[0] = '[' then
             List.distinct nestedRgs
@@ -76,12 +76,12 @@ type ResourceGroupDeployment =
             this.Parameters |> List.where(fun p -> inputParameterKeys |> Set.contains p.Key |> not)
     interface IArmResource with
         member this.ResourceId = this.ResourceId
-        member this.JsonModel = 
+        member this.JsonModel =
             {| resourceGroupDeployment.Create(this.DeploymentName, this.Location, dependsOn = this.Dependencies, tags = this.Tags ) with
                 location = null // location is not supported for nested resource groups
                 resourceGroup = this.TargetResourceGroup.Value
                 subscriptionId = this.SubscriptionId |> Option.map string<System.Guid> |> Option.toObj
-                properties = 
+                properties =
                     {|  template = TemplateGeneration.processTemplate this.Template
                         parameters =
                             let parameters = Dictionary<string,obj>()
@@ -91,13 +91,13 @@ type ResourceGroupDeployment =
                             for inputParam in this.ParameterValues do
                                 parameters.[inputParam.Key] <- inputParam.ParamValue
                             parameters
-                        mode = 
+                        mode =
                           match this.Mode with
                           | Incremental -> "Incremental"
                           | Complete -> "Complete"
                         expressionEvaluationOptions = {| scope = "Inner" |}
                     |}
-            |} :> _
+            |}
 
 /// Resource Group as a subscription level resource - only for use in deployments targeting a subscription.
 type ResourceGroup =
@@ -109,5 +109,5 @@ type ResourceGroup =
         member this.JsonModel =
             {| resourceGroups.Create (this.Name, this.Location, this.Dependencies, this.Tags) with
                 properties = {| |}
-            |} :> _
+            |}
         member this.ResourceId = resourceGroups.resourceId this.Name

--- a/src/Farmer/Arm/RoleAssignment.fs
+++ b/src/Farmer/Arm/RoleAssignment.fs
@@ -64,4 +64,4 @@ type RoleAssignment =
                     {| roleDefinitionId = this.RoleDefinitionId.ArmValue.Eval()
                        principalId = this.PrincipalId.ArmExpression.Eval()
                        principalType = this.PrincipalType.ArmValue |}
-            |}:> _
+            |}

--- a/src/Farmer/Arm/Search.fs
+++ b/src/Farmer/Arm/Search.fs
@@ -35,4 +35,4 @@ type SearchService =
                  {| replicaCount = this.ReplicaCount
                     partitionCount = this.PartitionCount
                     hostingMode = this.HostingMode |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -64,7 +64,7 @@ module Namespaces =
                                         sqlFilter = null |}
                             |}
                         ]
-                    |} :> _
+                    |}
 
     type Queue =
         { Name : ResourceName
@@ -97,7 +97,7 @@ module Namespaces =
                         maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
                         maxSizeInMegabytes = this.MaxSizeInMegabytes |> Option.toNullable
                         enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
-                |} :> _
+                |}
     type QueueAuthorizationRule =
         { Name : ResourceName
           Location : Location
@@ -108,7 +108,7 @@ module Namespaces =
             member this.JsonModel =
                 {| queueAuthorizationRules.Create(this.Name, this.Location, this.Dependencies) with
                     properties = {| rights = this.Rights |> Set.map string |> Set.toList |}
-                |} :> _
+                |}
 
     type NamespaceAuthorizationRule =
         { Name : ResourceName
@@ -120,7 +120,7 @@ module Namespaces =
             member this.JsonModel =
                 {| namespaceAuthorizationRules.Create(this.Name, this.Location, this.Dependencies) with
                     properties = {| rights = this.Rights |> Set.map string |> Set.toList |}
-                |} :> _
+                |}
 
     type Topic =
         { Name : ResourceName
@@ -143,7 +143,7 @@ module Namespaces =
                            duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
                            enablePartitioning = this.EnablePartitioning |> Option.toNullable
                            maxSizeInMegabytes = this.MaxSizeInMegabytes |> Option.toNullable |}
-                |} :> _
+                |}
 
 type Namespace =
     { Name : ResourceName
@@ -166,4 +166,4 @@ type Namespace =
                      {| name = this.Sku.NameArmValue
                         tier = this.Sku.TierArmValue
                         capacity = this.Capacity |> Option.toNullable |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/SignalR.fs
+++ b/src/Farmer/Arm/SignalR.fs
@@ -36,4 +36,4 @@ type SignalR =
                         {| flag = "ServiceMode"
                            value = this.ServiceMode.ToString() |}
                         ] |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -29,13 +29,13 @@ type Server =
                  {| administratorLogin = this.Credentials.Username
                     administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
                     version = "12.0"
-                    minimalTlsVersion = 
+                    minimalTlsVersion =
                         match this.MinTlsVersion with
                         | Some Tls10 -> "1.0"
                         | Some Tls11 -> "1.1"
                         | Some Tls12 -> "1.2"
                         | None -> null |}
-            |} :> _
+            |}
 
 module Servers =
     type ElasticPool =
@@ -56,7 +56,7 @@ module Servers =
                          | Some (min, max) -> box {| minCapacity = min; maxCapacity = max |}
                          | None -> null
                      |}
-                    sku = {| name = this.Sku.Name; tier = this.Sku.Edition; size = string this.Sku.Capacity |} |} :> _
+                    sku = {| name = this.Sku.Name; tier = this.Sku.Edition; size = string this.Sku.Capacity |} |}
 
     type FirewallRule =
         { Name : ResourceName
@@ -71,7 +71,7 @@ module Servers =
                     properties =
                      {| startIpAddress = string this.Start
                         endIpAddress = string this.End |}
-                |} :> _
+                |}
 
     type Database =
         { Name : ResourceName
@@ -109,7 +109,7 @@ module Servers =
                             | Standalone _ -> null
                             | Pool pool -> elasticPools.resourceId(this.Server.ResourceName, pool).Eval()
                         |}
-                |} :> _
+                |}
 
     module Databases =
         type TransparentDataEncryption =
@@ -122,4 +122,4 @@ module Servers =
                    {| transparentDataEncryption.Create(this.Name, dependsOn = [ databases.resourceId(this.Server.ResourceName, this.Database) ]) with
                         comments = "Transparent Data Encryption"
                         properties = {| status = string Enabled |}
-                   |} :> _
+                   |}

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -137,7 +137,7 @@ type StorageAccount =
                         | Some Tls12 -> "TLS1_2"
                         | None -> null
                     |}
-            |} :> _
+            |}
     interface IPostDeploy with
         member this.Run _ =
             this.StaticWebsite
@@ -234,7 +234,7 @@ type StorageService =
                             |> Option.map resolvePolicy
                             |> Option.defaultValue null
                     |}
-            |} :> _
+            |}
 
 module BlobServices =
     type Container =
@@ -251,7 +251,7 @@ module BlobServices =
                          | Private -> "None"
                          | Container -> "Container"
                          | Blob -> "Blob" |}
-                |} :> _
+                |}
 
 module FileShares =
     type FileShare =
@@ -263,7 +263,7 @@ module FileShares =
             member this.JsonModel =
                 {| fileShares.Create(this.StorageAccount/"default"/this.Name.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ]) with
                     properties = {| shareQuota = this.ShareQuota |> Option.defaultValue 5120<Gb> |}
-                |} :> _
+                |}
 
 module Tables =
     type Table =
@@ -272,7 +272,7 @@ module Tables =
         interface IArmResource with
             member this.ResourceId = tables.resourceId (this.StorageAccount/"default"/this.Name.ResourceName)
             member this.JsonModel =
-                tables.Create(this.StorageAccount/"default"/this.Name.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ]) :> _
+                tables.Create(this.StorageAccount/"default"/this.Name.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ])
 
 module Queues =
     type Queue =
@@ -281,7 +281,7 @@ module Queues =
         interface IArmResource with
             member this.ResourceId = queues.resourceId (this.StorageAccount/"default"/this.Name.ResourceName)
             member this.JsonModel =
-                queues.Create(this.StorageAccount/"default"/this.Name.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ]) :> _
+                queues.Create(this.StorageAccount/"default"/this.Name.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ])
 
 module ManagementPolicies =
     type ManagementPolicy =
@@ -324,4 +324,4 @@ module ManagementPolicies =
                              ]
                          |}
                      |}
-                |} :> _
+                |}

--- a/src/Farmer/Arm/TrafficManager.fs
+++ b/src/Farmer/Arm/TrafficManager.fs
@@ -66,4 +66,4 @@ type Profile =
                                toleratedNumberOfFailures = this.MonitorConfig.ToleratedNumberOfFailures
                                timeoutInSeconds = int this.MonitorConfig.TimeoutInSeconds |}
                           endpoints = this.Endpoints |> List.map (fun e -> e.JsonModel) |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/VirtualHub.fs
+++ b/src/Farmer/Arm/VirtualHub.fs
@@ -75,7 +75,7 @@ type VirtualHub =
                        sku = this.VirtualHubSku.ArmValue
                        virtualWan = this.Vwan |> Option.map (fun resId -> box {| id = resId.ArmExpression.Eval() |}) |> Option.defaultValue null
                     |}
-            |}:> _
+            |}
 
 open Farmer.VirtualHub.HubRouteTable
 type HubRoute =
@@ -106,4 +106,4 @@ type HubRouteTable =
                       routes = this.Routes |> List.map (fun r -> r.JsonModel)
                       labels = this.Labels
                     |}
-            |} :> _
+            |}

--- a/src/Farmer/Arm/VirtualWan.fs
+++ b/src/Farmer/Arm/VirtualWan.fs
@@ -44,4 +44,4 @@ type VirtualWan =
                        disableVpnEncryption = this.DisableVpnEncryption |> Option.defaultValue false
                        office365LocalBreakoutCategory = (this.Office365LocalBreakoutCategory |> Option.defaultValue Office365LocalBreakoutCategory.None).ArmValue
                        ``type`` = this.VwanType.ArmValue |}
-            |}:> _
+            |}

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -108,7 +108,7 @@ type ServerFarm =
                          reserved = this.Reserved
                          maximumElasticWorkerCount = this.MaximumElasticWorkerCount |> Option.toNullable |}
                  kind = this.Kind |> Option.toObj
-            |} :> _
+            |}
 
 module ZipDeploy =
     open System.IO
@@ -292,7 +292,7 @@ type Site =
                            autoSwapSlotName = this.AutoSwapSlotName |> Option.toObj
                         |}
                     |}
-            |} :> _
+            |}
 
 module Sites =
     type SourceControl =
@@ -310,7 +310,7 @@ module Sites =
                         {| repoUrl = this.Repository.ToString()
                            branch = this.Branch
                            isManualIntegration = this.ContinuousIntegration.AsBoolean |> not |}
-                |} :> _
+                |}
 
 type StaticSite =
     { Name : ResourceName
@@ -337,7 +337,7 @@ type StaticSite =
                 sku =
                  {| Tier = "Free"
                     Name = "Free" |}
-            |} :> _
+            |}
     interface IParameters with
         member this.SecureParameters = [
             this.RepositoryToken
@@ -373,7 +373,7 @@ type HostNameBinding =
                             {| sslState = "SniEnabled"
                                thumbprint = thumbprint.Eval() |} :> obj
                         | SslDisabled -> {| |} :> obj
-                |} :> _
+                |}
 
 type Certificate =
     { Location: Location
@@ -398,7 +398,7 @@ type Certificate =
                     properties =
                         {| serverFarmId = this.ServicePlanId.ResourceId.Eval()
                            canonicalName = this.DomainName |}
-                |} :> _
+                |}
 
 type SlotConfigName = 
     { SiteName : ResourceName
@@ -420,7 +420,7 @@ module SiteExtensions =
         interface IArmResource with
             member this.ResourceId = siteExtensions.resourceId(this.SiteName/this.Name)
             member this.JsonModel =
-                siteExtensions.Create(this.SiteName/this.Name, this.Location, [ sites.resourceId this.SiteName ]) :> _
+                siteExtensions.Create(this.SiteName/this.Name, this.Location, [ sites.resourceId this.SiteName ])
 
 module ContainerApp =
     open Farmer.ContainerAppValidation
@@ -633,7 +633,7 @@ module ContainerApp =
                                               :> obj
                                    |}
                        |}
-                |} :> _
+                |}
 
     type KubeEnvironment =
         { Name : ResourceName
@@ -657,4 +657,4 @@ module ContainerApp =
                                   sharedKey = LogAnalytics.getPrimarySharedKey(this.LogAnalytics).Eval() |}
                             |}
                         |}
-                |} :> _
+                |}

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -380,7 +380,7 @@ type Certificate =
       SiteId: LinkedResource
       ServicePlanId: LinkedResource
       DomainName: string }
-        member this.ResourceName = this.SiteId.Name.Map (sprintf "%s-cert")
+        member this.ResourceName = ResourceName this.DomainName
         member this.Thumbprint = this.GetThumbprintReference None
         member this.GetThumbprintReference certificateResourceGroup =
             ArmExpression.reference({certificates.resourceId this.ResourceName with ResourceGroup = certificateResourceGroup}).Map(sprintf "%s.Thumbprint")

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -115,7 +115,7 @@ type ExpressRouteConfig =
                          VlanId = peering.VlanId |}
               ]
               Tags = this.Tags
-            } :> _
+            }
             ::
             (this.Authorizations |> List.map (fun a ->
                 { ExpressRouteCircuitAuthorization.Name = a

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -202,8 +202,8 @@ type WebAppConfig =
       DockerAcrCredentials : {| RegistryName : string; Password : SecureParameter |} option
       AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
-      PrivateEndpoints: (LinkedResource * string option) Set 
-      CustomDomain : DomainConfig }
+      PrivateEndpoints: (LinkedResource * string option) Set
+      CustomDomains : Map<string,DomainConfig> }
     member this.Name = this.CommonWebConfig.Name
     /// Gets this web app's Server Plan's full resource ID.
     member this.ServicePlanId = this.CommonWebConfig.ServicePlan.resourceId this.Name.ResourceName
@@ -373,6 +373,7 @@ type WebAppConfig =
                         | None ->
                             match this.Runtime with
                             | DotNetCore version -> Some $"DOTNETCORE|{version}"
+                            | DotNet version -> Some $"DOTNETCORE|{version}"
                             | Node version -> Some $"NODE|{version}"
                             | Php version -> Some $"PHP|{version}"
                             | Ruby version -> Some $"RUBY|{version}"
@@ -482,64 +483,64 @@ type WebAppConfig =
                 { site with AppSettings = None; ConnectionStrings = None } // Don't deploy production slot settings as they could cause an app restart
                 for (_,slot) in this.CommonWebConfig.Slots |> Map.toSeq do
                     slot.ToSite site
+                
+            for customDomain in this.CustomDomains |> Map.toSeq |> Seq.map snd do
+                match customDomain with
+                | SecureDomain (customDomain, certOptions) ->
+                    let hostNameBinding =
+                        { Location = location
+                          SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
+                          DomainName = customDomain
+                          SslState = SslDisabled } // Initially create non-secure host name binding, we link the certificate in a nested deployment below
+                    let cert =
+                        { Location = location
+                          SiteId = Managed this.ResourceId
+                          ServicePlanId = Managed this.ServicePlanId
+                          DomainName = customDomain }
+                    hostNameBinding
 
-            match this.CustomDomain with
-            | SecureDomain (customDomain, certOptions) ->
-                let hostNameBinding =
+                    // Get the resource group which contains the app service plan
+                    let aspRgName = 
+                      match this.CommonWebConfig.ServicePlan with
+                      | LinkedResource linked -> linked.ResourceId.ResourceGroup
+                      | _ -> None
+                    // Create a nested resource group deployment for the certificate - this isn't strictly necessary when the app & app service plan are in the same resource group
+                    // however, when they are in different resource groups this is required to make the deployment succeed (there is an ARM bug which causes a Not Found / Conflict otherwise)
+                    // To keep the code simple, I opted to always nest the certificate deployment. - TheRSP 2021-12-14
+                    let certRg = resourceGroup { 
+                        name (aspRgName |> Option.defaultValue "[resourceGroup().name]")
+                        add_resource 
+                          { cert with
+                              SiteId = Unmanaged cert.SiteId.ResourceId
+                              ServicePlanId = Unmanaged cert.ServicePlanId.ResourceId }
+                        depends_on cert.SiteId
+                        depends_on (hostNameBindings.resourceId(cert.SiteId.Name, ResourceName cert.DomainName))
+                    }
+                    yield! ((certRg :> IBuilder).BuildResources location)
+
+                    // Need to rename `location` binding to prevent conflict with `location` operator in resource group
+                    let resourceLocation = location
+                    // nested deployment to update hostname binding with specified SSL options
+                    yield! (resourceGroup { 
+                        name "[resourceGroup().name]"
+                        location resourceLocation
+                        add_resource { hostNameBinding with
+                                        SiteId =
+                                            match hostNameBinding.SiteId with 
+                                            | Managed id -> Unmanaged id
+                                            | x -> x 
+                                        SslState = 
+                                            match certOptions with
+                                            | AppManagedCertificate -> SniBased (cert.GetThumbprintReference aspRgName)
+                                            | CustomCertificate thumbprint -> SniBased thumbprint
+                                      }
+                        depends_on certRg
+                    } :> IBuilder).BuildResources location
+                | InsecureDomain customDomain -> 
                     { Location = location
                       SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
                       DomainName = customDomain
-                      SslState = SslDisabled } // Initially create non-secure host name binding, we link the certificate in a nested deployment below
-                let cert =
-                    { Location = location
-                      SiteId = Managed this.ResourceId
-                      ServicePlanId = Managed this.ServicePlanId
-                      DomainName = customDomain }
-                hostNameBinding
-
-                // Get the resource group which contains the app service plan
-                let aspRgName = 
-                  match this.CommonWebConfig.ServicePlan with
-                  | LinkedResource linked -> linked.ResourceId.ResourceGroup
-                  | _ -> None
-                // Create a nested resource group deployment for the certificate - this isn't strictly necessary when the app & app service plan are in the same resource group
-                // however, when they are in different resource groups this is required to make the deployment succeed (there is an ARM bug which causes a Not Found / Conflict otherwise)
-                // To keep the code simple, I opted to always nest the certificate deployment. - TheRSP 2021-12-14
-                let certRg = resourceGroup { 
-                    name (aspRgName |> Option.defaultValue "[resourceGroup().name]")
-                    add_resource 
-                      { cert with
-                          SiteId = Unmanaged cert.SiteId.ResourceId
-                          ServicePlanId = Unmanaged cert.ServicePlanId.ResourceId }
-                    depends_on cert.SiteId
-                    depends_on (hostNameBindings.resourceId(cert.SiteId.Name, ResourceName cert.DomainName))
-                }
-                yield! ((certRg :> IBuilder).BuildResources location)
-
-                // Need to rename `location` binding to prevent conflict with `location` operator in resource group
-                let resourceLocation = location
-                // nested deployment to update hostname binding with specified SSL options
-                yield! (resourceGroup { 
-                    name "[resourceGroup().name]"
-                    location resourceLocation
-                    add_resource { hostNameBinding with
-                                    SiteId =
-                                        match hostNameBinding.SiteId with 
-                                        | Managed id -> Unmanaged id
-                                        | x -> x 
-                                    SslState = 
-                                        match certOptions with
-                                        | AppManagedCertificate -> SniBased (cert.GetThumbprintReference aspRgName)
-                                        | CustomCertificate thumbprint -> SniBased thumbprint
-                                  }
-                    depends_on certRg
-                } :> IBuilder).BuildResources location
-            | InsecureDomain customDomain -> 
-                { Location = location
-                  SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
-                  DomainName = customDomain
-                  SslState = SslDisabled }
-            | NoDomain -> ()
+                      SslState = SslDisabled }
             
             if this.CommonWebConfig.SlotSettingNames <> Set.empty then
                 {
@@ -590,7 +591,7 @@ type WebAppBuilder() =
           AutomaticLoggingExtension = true
           SiteExtensions = Set.empty
           PrivateEndpoints = Set.empty
-          CustomDomain = NoDomain }
+          CustomDomains = Map.empty }
     member _.Run(state:WebAppConfig) =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Web App name has been set."
         { state with
@@ -690,9 +691,9 @@ type WebAppBuilder() =
     member _.DefaultLogging (state:WebAppConfig, setting) = { state with AutomaticLoggingExtension = setting }
     //Add Custom domain to you web app
     [<CustomOperation "custom_domain">]
-    member _.CustomDomain(state:WebAppConfig, domainConfig) = { state with CustomDomain = domainConfig }
-    member _.CustomDomain(state:WebAppConfig, customDomain) = { state with CustomDomain = SecureDomain (customDomain,AppManagedCertificate) }
-    member _.CustomDomain(state:WebAppConfig, (customDomain,thumbprint)) = { state with CustomDomain = SecureDomain (customDomain,CustomCertificate thumbprint) }
+    member _.AddCustomDomain(state:WebAppConfig, domainConfig:DomainConfig) = { state with CustomDomains = state.CustomDomains |> Map.add domainConfig.DomainName domainConfig }
+    member this.AddCustomDomain(state:WebAppConfig, customDomain) = this.AddCustomDomain (state, SecureDomain (customDomain,AppManagedCertificate))
+    member this.AddCustomDomain(state:WebAppConfig, (customDomain,thumbprint)) = this.AddCustomDomain (state, SecureDomain (customDomain,CustomCertificate thumbprint))
 
     interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1456,6 +1456,10 @@ module CosmosDb =
     /// A request unit.
     [<Measure>]
     type RU
+    /// The throughput for CosmosDB account
+    type Throughput =
+        | Provisioned of int<RU>
+        | Serverless
 
 module PostgreSQL =
     type Sku =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.24</Version>
+    <Version>1.6.26</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
-    <Copyright>Copyright 2019-2021 Compositional IT Ltd.</Copyright>
+    <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
     <Authors>Isaac Abraham and contributors</Authors>
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -244,7 +244,11 @@ type CertificateOptions =
 type DomainConfig =
     | SecureDomain of domain:string * cert:CertificateOptions
     | InsecureDomain of domain:string
-    | NoDomain
+    member this.DomainName = 
+        match this with 
+        | SecureDomain (domainName,_)
+        | InsecureDomain (domainName) -> domainName
+
 
 [<AutoOpen>]
 module ResourceRef =

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -70,7 +70,7 @@ let tests = testList "Container Apps" [
     let jobj = JObject.Parse jsonTemplate
 
     test "Container automatically creates a log analytics workspace" {
-        let env : IBuilder = containerEnvironment { name "testca" } :> _
+        let env : IBuilder = containerEnvironment { name "testca" }
         let resources = env.BuildResources Location.NorthEurope
         Expect.exists resources (fun r -> r.ResourceId.Name.Value = "testca-workspace") "No Log Analytics workspace was created."
     }

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -519,7 +519,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "kind": "GlobalDocumentDB",
               "location": "uksouth",
               "name": "testaccount",
@@ -537,7 +537,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccount')]"
               ],
@@ -553,7 +553,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts/sqlDatabases', 'testaccount', 'testdb')]"
               ],
@@ -595,7 +595,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "kind": "MongoDB",
               "location": "uksouth",
               "name": "testaccountmongo",
@@ -613,7 +613,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccountmongo')]"
               ],


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add support for using `custom_domain` operator to add multiple domains to a webApp
* changed naming of cert resource to match domain name instead of webappName + `-cert`

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
