### PR TITLE
Add dependency when deploying multiple host name bindings to prevent error

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -351,7 +351,7 @@ type HostNameBinding =
       SiteId: LinkedResource
       DomainName: string
       SslState: SslState
-      DependsOn: Set<ResourceId> }
+      DependsOn: ResourceId Set }
         member this.SiteResourceId =
             match this.SiteId with
             | Managed id -> id.Name
@@ -359,9 +359,11 @@ type HostNameBinding =
         member this.ResourceName =
             this.SiteResourceId / this.DomainName
         member this.Dependencies =
-            match this.SiteId with
-            | Managed resid -> this.DependsOn.Add(resid)
-            | _ -> this.DependsOn
+            [ match this.SiteId with
+              | Managed resid -> resid
+              | _ -> ()
+
+              yield! this.DependsOn ]
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -350,7 +350,8 @@ type HostNameBinding =
     { Location: Location
       SiteId: LinkedResource
       DomainName: string
-      SslState: SslState }
+      SslState: SslState
+      DependsOn: Set<ResourceId> }
         member this.SiteResourceId =
             match this.SiteId with
             | Managed id -> id.Name
@@ -358,9 +359,9 @@ type HostNameBinding =
         member this.ResourceName =
             this.SiteResourceId / this.DomainName
         member this.Dependencies =
-            [ match this.SiteId with
-              | Managed resid -> resid
-              | _ -> () ]
+            match this.SiteId with
+            | Managed resid -> this.DependsOn.Add(resid)
+            | _ -> this.DependsOn
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -709,7 +709,7 @@ type WebAppBuilder() =
     [<CustomOperation "custom_domains">]
     member this.AddCustomDomains(state, customDomains:string list) = customDomains |> List.fold (fun state domain -> this.AddCustomDomain(state, domain)) state
     member this.AddCustomDomains(state, domainConfigs:DomainConfig list) = domainConfigs |> List.fold (fun state domain -> this.AddCustomDomain(state, domain)) state
-     member this.AddCustomDomains(state, customDomains:(string * ArmExpression) list) = customDomains |> List.fold (fun state domain -> this.AddCustomDomain(state, domain)) state
+    member this.AddCustomDomains(state, customDomainsWithThumprint:(string * ArmExpression) list) = customDomainsWithThumprint |> List.fold (fun state domain -> this.AddCustomDomain(state, domain)) state
 
     interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -725,7 +725,37 @@ let tests = testList "Web App Tests" [
         
         Expect.equal secureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal insecureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+    }
 
+    test "Assigns dependencies to host names when deploying multiple custom domains" {
+        let webappName = "test"
+        let resources = 
+            webApp {
+                name webappName
+                custom_domains ["secure1.io" ; "secure2.io" ; "secure3.io"]
+            } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+
+        let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
+
+        //Testing HostnameBinding
+        let hostnameBindings = resources |> getResource<Web.HostNameBinding> 
+        let secureBinding1 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure1.io") |> List.head
+        let secureBinding2 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure2.io") |> List.head
+        let secureBinding3 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure3.io") |> List.head
+        let nestedResourceGroupHostNameUpdates = 
+            resources 
+            |> getResource<ResourceGroupDeployment> 
+            |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
+            |> Seq.filter(fun x -> x.Length > 0)
+
+        Expect.all nestedResourceGroupHostNameUpdates (fun x -> x.Head.DependsOn.IsEmpty) "No dependencies expected on nested template"
+        Expect.equal secureBinding1.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.equal secureBinding2.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.equal secureBinding3.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.isEmpty secureBinding1.DependsOn "First host name binding should have no dependency"
+        Expect.contains (secureBinding2.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure1.io')]" "Second host name binding should depend on first"
+        Expect.contains (secureBinding3.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure2.io')]" "Third host name binding depends on second"
     }
     
     test "Supports slot settings" {


### PR DESCRIPTION
The changes in this PR are as follows:
* Ensures that multiple `HostNameBindings` can be deployed sequentially by assigning a dependency.
* Adds a couple of `custom_domains` operations to add multiple domains.
* Minor refactor.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription (this actually failed as I didn't have the capability of adding a TXT record for a second custom domain)
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let api = webApp {
    name "app"
    custom_domains ["secure1.io" ; "secure2.io" ; "secure3.io"]
}

arm {
  location Location.UKSouth
  add_resource api
}
```
