### PR TITLE
remove Logging Extension when AutomaticLoggingExtension is off

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -614,6 +614,8 @@ type WebAppBuilder() =
                 // No route registered for '/api/siteextensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension'
                 | { Runtime = Runtime.DotNetCore _; AutomaticLoggingExtension = true ; DockerImage = None } ->
                     state.SiteExtensions.Add WebApp.Extensions.Logging
+                | { AutomaticLoggingExtension = false } ->
+                    state.SiteExtensions.Remove WebApp.Extensions.Logging
                 | _ ->
                     state.SiteExtensions
             DockerImage =


### PR DESCRIPTION
This PR closes #34760

When we create a Linux webapp using `Codat.DevOps.Deployment`, the default values in wrapper add Logging extension to the SiteExtensions lists. Later when we explicitly set `automatic_logging_extension false` the LoggingExtension doesn't get removed. Currently, it is causing a problem when we create a Linux webapp. Linux doesn't support site extensions. 

The changes in this PR are as follows:

* remove Logging Extension when AutomaticLoggingExtension is off

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
