### PR TITLE
Move previous host name dependency to entire deploy

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -363,8 +363,7 @@ type HostNameBinding =
     { Location: Location
       SiteId: LinkedResource
       DomainName: string
-      SslState: SslState
-      DependsOn: ResourceId Set }
+      SslState: SslState }
         member this.SiteResourceId =
             match this.SiteId with
             | Managed id -> id.Name
@@ -374,9 +373,7 @@ type HostNameBinding =
         member this.Dependencies =
             [ match this.SiteId with
               | Managed resid -> resid
-              | _ -> ()
-
-              yield! this.DependsOn ]
+              | _ -> () ]
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -738,26 +738,34 @@ let tests = testList "Web App Tests" [
 
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
 
-        //Testing HostnameBinding
+        // Testing HostnameBinding
         let hostnameBindings = resources |> getResource<Web.HostNameBinding> 
         let secureBinding1 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure1.io") |> List.head
         let secureBinding2 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure2.io") |> List.head
         let secureBinding3 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure3.io") |> List.head
-        let nestedResourceGroupHostNameUpdates = 
-            resources 
-            |> getResource<ResourceGroupDeployment> 
-            |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
-            |> Seq.filter(fun x -> x.Length > 0)
 
-        Expect.all nestedResourceGroupHostNameUpdates (fun x -> x.Head.DependsOn.IsEmpty) "No dependencies expected on nested template"
         Expect.equal secureBinding1.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal secureBinding2.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal secureBinding3.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
-        Expect.isEmpty secureBinding1.DependsOn "First host name binding should have no dependency"
-        Expect.contains (secureBinding2.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure1.io')]" "Second host name binding should depend on first"
-        Expect.contains (secureBinding3.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure2.io')]" "Third host name binding depends on second"
+
+        // Testing dependencies.
+        let nestedHostNameResourceGroups = 
+            resources 
+            |> getResource<ResourceGroupDeployment> 
+            |> Seq.filter(fun x -> getResource<Web.HostNameBinding>(x.Resources) |> Seq.isEmpty |> not)
+            |> Seq.toList
+
+        let dependentHostNameResourceGroups = 
+            nestedHostNameResourceGroups
+            |> Seq.map(fun rg -> rg.Dependencies |> Seq.filter(fun dep -> nestedHostNameResourceGroups |> Seq.exists(fun x -> x.DeploymentName = dep.Name)))
+            |> Seq.map(fun deps -> deps |> Seq.map(fun dep -> dep.Name))
+            |> Seq.toList
+
+        Expect.hasLength nestedHostNameResourceGroups 3 "Should have three host name deploys"
+        Expect.isEmpty dependentHostNameResourceGroups[0] "First host name binding should not depend on another"
+        Expect.contains dependentHostNameResourceGroups[1] nestedHostNameResourceGroups[0].ResourceId.Name "Second host name binding should depend on first deploy"
+        Expect.contains dependentHostNameResourceGroups[2] nestedHostNameResourceGroups[1].ResourceId.Name "Third host name binding should depend on second deploy"
     }
-      
 
     test "Supports adding ip restriction for allowed ip" {
         let ip = IPAddressCidr.parse "1.2.3.4/32"


### PR DESCRIPTION
This PR closes [#34904](https://dev.azure.com/codat/Codat/_boards/board/t/Devops%20Working%20Group/Stories/?workitem=34904)

The changes in this PR are as follows:
* Remove direct `DependsOn` for host name binding in favour of a dependency to the entire previous deployment.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
I can't test this end to end owing to insufficient cloudflare permissions and a lack of an existing app in integration that has multiple domains. I'd like to merge this to the Codat fork and test before submitting a PR to CompositionalIT.
