### PR TITLE
Move dependency on site from hostname resource to the hostname deployment

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -365,21 +365,15 @@ type HostNameBinding =
       DomainName: string
       SslState: SslState }
         member this.SiteResourceId =
-            match this.SiteId with
-            | Managed id -> id.Name
-            | Unmanaged id -> id.Name
+            this.SiteId.Name
         member this.ResourceName =
             this.SiteResourceId / this.DomainName
-        member this.Dependencies =
-            [ match this.SiteId with
-              | Managed resid -> resid
-              | _ -> () ]
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with
             member this.ResourceId = hostNameBindings.resourceId this.ResourceName
             member this.JsonModel =
-                {| hostNameBindings.Create(this.ResourceName, this.Location, this.Dependencies) with
+                {| hostNameBindings.Create(this.ResourceName, this.Location) with
                     properties =
                         match this.SslState with
                         | SniBased thumbprint ->

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -532,8 +532,8 @@ type WebAppConfig =
 
                 let dependsOn : ResourceId list = 
                   match previousHostNameCertificateLinkingDeployment with
-                  | Some previous -> [ previous ]
-                  | None -> []
+                  | Some previous -> [ previous; this.ResourceId ]
+                  | None -> [ this.ResourceId ]
 
                 let hostNameBindingDeployment = resourceGroup {
                     name "[resourceGroup().name]"


### PR DESCRIPTION
The changes in this PR are as follows:
* Move dependency from host name to site.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Written unit tests** against the modified code that I have made.

This has been tested on a live subscription and worked six times in a row - so HOPEFULLY we shouldn't see the conflicts anymore.
