### PR TITLE
Stop disabling TLS temporarily during deployment

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -436,7 +436,7 @@ type HostNameBinding =
     { Location: Location
       SiteId: LinkedResource
       DomainName: string
-      SslState: SslState }
+      SslState: SslState option}
         member this.SiteResourceId =
             this.SiteId.Name
         member this.ResourceName =
@@ -449,10 +449,11 @@ type HostNameBinding =
                 {| hostNameBindings.Create(this.ResourceName, this.Location) with
                     properties =
                         match this.SslState with
-                        | SniBased thumbprint ->
+                        | Some (SniBased thumbprint) ->
                             {| sslState = "SniEnabled"
                                thumbprint = thumbprint.Eval() |} :> obj
-                        | SslDisabled -> {| |} :> obj
+                        | Some SslDisabled -> {| |} :> obj
+                        | None -> null
                 |}
 
 type Certificate =

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -625,7 +625,7 @@ type WebAppConfig =
                     { Location = location
                       SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
                       DomainName = customDomain.DomainName
-                      SslState = SslDisabled } // Initially create non-secure host name binding, we link the certificate in a nested deployment below
+                      SslState = None } // Initially create non-secure host name binding, we link the certificate in a nested deployment below
 
                 let dependsOn : ResourceId list = 
                   match previousHostNameCertificateLinkingDeployment with
@@ -681,8 +681,8 @@ type WebAppConfig =
                                             | x -> x 
                                         SslState = 
                                             match certOptions with
-                                            | AppManagedCertificate -> SniBased (cert.GetThumbprintReference aspRgName)
-                                            | CustomCertificate thumbprint -> SniBased thumbprint
+                                            | AppManagedCertificate -> Some(SniBased (cert.GetThumbprintReference aspRgName))
+                                            | CustomCertificate thumbprint -> Some(SniBased thumbprint)
                                       }
                         depends_on certificateDeployment.ResourceId
                      }

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -646,7 +646,7 @@ let tests = testList "Web App Tests" [
 
         // Testing HostnameBinding
         let hostnameBinding = nested.[0].Resources |> getResource<Web.HostNameBinding> |> List.head
-        let expectedSslState = SslState.SslDisabled
+        let expectedSslState = None
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         Expect.equal hostnameBinding.DomainName expectedDomainName $"HostnameBinding domain name should have {expectedDomainName}"
         Expect.equal hostnameBinding.SslState expectedSslState $"HostnameBinding should have a {expectedSslState} Ssl state"
@@ -659,7 +659,7 @@ let tests = testList "Web App Tests" [
         // Testing hostname/certificate link.
         let bindingDeployment = nested.[2]
         let innerResource = bindingDeployment.Resources |> getResource<Web.HostNameBinding> |> List.head
-        let innerExpectedSslState = SslState.SniBased thumbprint
+        let innerExpectedSslState = Some (SslState.SniBased thumbprint)
         Expect.stringStarts bindingDeployment.DeploymentName.Value "[concat" "resourceGroupDeployment name should start as a valid ARM expression"
         Expect.stringEnds bindingDeployment.DeploymentName.Value ")]" "resourceGroupDeployment stage should end as a valid ARM expression"
         Expect.equal bindingDeployment.Resources.Length 1 "resourceGroupDeployment stage should only contain one resource"
@@ -676,7 +676,7 @@ let tests = testList "Web App Tests" [
         
         // Testing HostnameBinding
         let hostnameBinding = nested.[0].Resources |> getResource<Web.HostNameBinding> |> List.head
-        let expectedSslState = SslState.SslDisabled
+        let expectedSslState = None
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         Expect.equal hostnameBinding.DomainName expectedDomainName $"HostnameBinding domain name should have {expectedDomainName}"
         Expect.equal hostnameBinding.SslState expectedSslState $"HostnameBinding should have a {expectedSslState} Ssl state"
@@ -689,7 +689,7 @@ let tests = testList "Web App Tests" [
         // Testing hostname/certificate link.
         let bindingDeployment = nested.[2]
         let innerResource = bindingDeployment.Resources |> getResource<Web.HostNameBinding> |> List.head
-        let innerExpectedSslState = SslState.SniBased cert.Thumbprint
+        let innerExpectedSslState = Some (SslState.SniBased cert.Thumbprint)
         Expect.equal bindingDeployment.Resources.Length 1 "resourceGroupDeployment stage should only contain one resource"
         Expect.equal bindingDeployment.Dependencies.Count 1 "resourceGroupDeployment stage should only contain one dependencies"
         Expect.equal innerResource.SslState innerExpectedSslState $"hostnameBinding should have a {innerExpectedSslState} Ssl state inside the resourceGroupDeployment template"
@@ -707,7 +707,7 @@ let tests = testList "Web App Tests" [
               |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
               |> Seq.concat
               |> Seq.head
-        let expectedSslState = SslState.SslDisabled
+        let expectedSslState = None
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         let expectedDomainName = "customDomain.io"
 


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* set hostNameBinding properties to null so as not to modify existing settings if the resource already exists but to create an insecure binding if the resource does not exist

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
