### PR TITLE
Ensure CURRENT_STACK is set in metadata

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -541,7 +541,7 @@ type WebAppConfig =
                     | Php _, _ -> Some "php"
                     | Python _, Windows -> Some "python"
                     | DotNetCore _, Windows -> Some "dotnetcore"
-                    | AspNet _, _ | DotNet "5.0", Windows -> Some "dotnet"
+                    | AspNet _, _ | DotNet _, Windows -> Some "dotnet"
                     | _ -> None
                     |> Option.map(fun stack -> "CURRENT_STACK", stack)
                     |> Option.toList

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -316,14 +316,9 @@ let tests = testList "Web App Tests" [
 
     test "Supports .NET 6" {
         let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
-        let site:Site = app |> getResourceAtIndex 2
-        Expect.equal site.SiteConfig.NetFrameworkVersion "v6.0" "Wrong dotnet version"
-    }
-
-    test "Supports .NET 6 EAP" {
-        let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
-        let site:Site = app |> getResourceAtIndex 2
-        Expect.equal site.SiteConfig.NetFrameworkVersion "v6.0" "Wrong dotnet version"
+        let site = app |> getResources |> getResource<Web.Site> |> List.head
+        Expect.equal site.NetFrameworkVersion.Value "v6.0" "Wrong dotnet version"
+        Expect.equal site.Metadata.Head ("CURRENT_STACK", "dotnet") "Stack should be dotnet"
     }
 
     test "Supports .NET 5 on Linux" {


### PR DESCRIPTION
The changes in this PR are as follows:

* Ensure `CURRENT_STACK` is set when using `RuntimeStack.DotNet60`.
* Remove duplicate test.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
