### PR TITLE
Raise error when appname is too long for use with slots

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -88,7 +88,13 @@ type SlotConfig =
       Dependencies: ResourceId Set
       IpSecurityRestrictions: IpSecurityRestriction list }
     member this.ToSite (owner: Arm.Web.Site) =
-        { owner with
+        // https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots
+        let maxAppNameLengthWhenUsingSlots = 40
+        let errorMsg = $"App name '{owner.Name.Value}' has length={owner.Name.Value.Length}, which exceeds max length ({maxAppNameLengthWhenUsingSlots}) so cannot be used with slots"
+        if(owner.Name.Value.Length > maxAppNameLengthWhenUsingSlots) then Exceptions.raiseFarmer errorMsg 
+
+        { 
+          owner with
             SiteType = SiteType.Slot (owner.Name/this.Name)
             Dependencies = owner.Dependencies |> Set.add (owner.ResourceType.resourceId owner.Name)
             AutoSwapSlotName = this.AutoSwapSlotName

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -93,8 +93,7 @@ type SlotConfig =
         let errorMsg = $"App name '{owner.Name.Value}' has length={owner.Name.Value.Length}, which exceeds max length ({maxAppNameLengthWhenUsingSlots}) so cannot be used with slots"
         if(owner.Name.Value.Length > maxAppNameLengthWhenUsingSlots) then Exceptions.raiseFarmer errorMsg 
 
-        { 
-          owner with
+        { owner with
             SiteType = SiteType.Slot (owner.Name/this.Name)
             Dependencies = owner.Dependencies |> Set.add (owner.ResourceType.resourceId owner.Name)
             AutoSwapSlotName = this.AutoSwapSlotName

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -367,7 +367,6 @@ let tests = testList "Web App Tests" [
             |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
 
         let toExceptionMessage(ex:Exception) = ex.Message
-
         let exceptionMessage = Expect.throwsC (fun () -> createSlots() |> ignore) toExceptionMessage
         let expectedExceptionMessage = 
           "App name 'app-name-that-is-longer-than-40-characters' has length=42, which exceeds max length (40) so cannot be used with slots"

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -341,6 +341,40 @@ let tests = testList "Web App Tests" [
         Expect.hasLength slots 1 "Should only be 1 slot"
     }
 
+    test "WebApp supports adding slots when appName length does not exceed 40 characters" {
+        let slot = appSlot { name "warm-up" }
+        let site:WebAppConfig = webApp { name "appname-that-is--exactly--40--characters"; add_slot slot; zip_deploy "test.zip" }
+        Expect.isTrue (site.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
+
+        let slots =
+            site
+            |> getResources
+            |> getResource<Arm.Web.Site>
+            |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
+        // Default "production" slot is not included as it is created automatically in Azure
+        Expect.hasLength slots 1 "Should only be 1 slot"
+    }
+
+    test "WebApp does not support adding slots when appName is too long" {
+        let slot = appSlot { name "warm-up" }
+        let site:WebAppConfig = webApp { name "app-name-that-is-longer-than-40-characters"; add_slot slot; zip_deploy "test.zip" }
+        Expect.isTrue (site.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
+
+        let createSlots() =
+            site
+            |> getResources
+            |> getResource<Arm.Web.Site>
+            |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
+
+        let toExceptionMessage(ex:Exception) = ex.Message
+
+        let exceptionMessage = Expect.throwsC (fun () -> createSlots() |> ignore) toExceptionMessage
+        let expectedExceptionMessage = 
+          "App name 'app-name-that-is-longer-than-40-characters' has length=42, which exceeds max length (40) so cannot be used with slots"
+
+        Expect.equal exceptionMessage expectedExceptionMessage "Unexpected exception"
+     }
+    
     test "WebApp with slot and zip_deploy_slot does not have ZipDeployPath on slot" {
         let slot = appSlot { name "warm-up" }
         let site:WebAppConfig = webApp { name "slots"; add_slot slot; zip_deploy_slot "warm-up" "test.zip" }


### PR DESCRIPTION
The changes in this PR are as follows:

* Raise an error when adding a slot to an app, if the app name is longer than 40 characters
* Context: App names longer then 40 characters are automatically truncated by Azure when creating slot domain names

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
