### PR TITLE
Add support for Redis private endpoints

### DIFF
--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -64,6 +64,12 @@ type RedisBuilder() =
     [<CustomOperation "name">]
     member _.Name(state:RedisConfig, name) = { state with Name = name }
     member this.Name(state:RedisConfig, name) = this.Name(state, ResourceName name)
+    /// Sets the sku of the Redis instance to Standard and configures capacity     
+    [<CustomOperation "sku">]
+    member _.Sku(state:RedisConfig, capacity: Standard_WithCapacity) = { state with Sku = Redis.Standard; Capacity = int capacity }    
+    /// Sets the sku of the Redis instance to Premium and configures capacity     
+    [<CustomOperation "sku">]
+    member _.Sku(state:RedisConfig, capacity: Premium_WithCapacity) = { state with Sku = Redis.Premium; Capacity = int capacity }    
     /// Sets the sku of the Redis instance.
     [<CustomOperation "sku">]
     member _.Sku(state:RedisConfig, sku) = { state with Sku = sku }

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -479,6 +479,8 @@ type PrivateEndpointBuilder() =
     member _.PrivateLinkConnection(state:PrivateEndpointConfig, resource:LinkedResource) = 
         let outputResource, groupIds, dependencies =
             match resource.ResourceId.Type.Type with
+            // https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource
+              "Microsoft.Cache/Redis" ->  resource,["redisCache"],[]
             | "Microsoft.Web/sites" -> resource,["sites"],[]
             | "Microsoft.Web/sites/slots" -> 
                 match resource.ResourceId.Segments |> List.tryHead with

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1162,6 +1162,17 @@ module ContainerService =
 module Redis =
     type Sku = Basic | Standard | Premium
 
+    type Standard_WithCapacity = 
+        | ``250 MB`` = 0
+        | ``1 GB`` = 1
+        | ``2.5 GB`` = 2
+        | ``6 GB`` = 3
+        | ``13 GB`` = 4
+
+    type Premium_WithCapacity =
+        | ``6 GB`` = 1
+        | ``13 GB`` = 2
+
 module EventHub =
     /// The SKU of the event hub instance.
     type EventHubSku =

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -64,6 +64,7 @@ let allTests =
                 Dashboards.tests
                 Alerts.tests
                 ServicePlan.tests
+                Redis.tests
             ]
             testList "Control" [
                 if (hasEnv "TF_BUILD" "True" && notEnv "BUILD_REASON" "PullRequest") || hasEnv "FARMER_E2E" "True" then

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -454,4 +454,18 @@ let tests = testList "Network Tests" [
         Expect.equal ["sites-slotName"] armPe.GroupIds "private endpoint groupIds should match slot name"
         Expect.equal (Arm.Web.sites.resourceId (ResourceName "webApp") |> Unmanaged) armPe.Resource "private endpoint resource should match parent site name"
     }
+    test "Can create private endpoint for Redis" {
+        let peConfig = 
+          privateEndpoint {
+              name "privateendpoint"
+              subnet (subnets.resourceId "some-subnet" |> Unmanaged |> SubnetReference.create)
+              link_to_resource (Arm.Cache.redis.resourceId(ResourceName "redisCacheName") |> Unmanaged)
+              link_to_private_dns_zone (Farmer.Arm.Dns.zones.resourceId("dnsZone") |> Unmanaged)
+          } :> IBuilder
+        let resources = peConfig.BuildResources Location.NorthEurope
+        let armPe = resources[0] :?> Arm.Network.PrivateEndpoint
+        
+        Expect.equal ["redisCache"] armPe.GroupIds "redisCache"
+        Expect.equal (Arm.Cache.redis.resourceId (ResourceName "redisCacheName") |> Unmanaged) armPe.Resource "private endpoint resource should match parent site name"
+    }
 ]

--- a/src/Tests/Redis.fs
+++ b/src/Tests/Redis.fs
@@ -1,0 +1,58 @@
+module Redis
+
+open System
+open Expecto
+open Farmer
+open Farmer.Arm.Cache
+open Farmer.Builders
+open Newtonsoft.Json.Linq
+
+let verifySku (redisCache:RedisConfig, expectedSku:string, expectedCapacity:int, expectedFamily:string) = 
+    let deployment = arm { add_resource redisCache }
+    let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+        
+    let sku = string(jobj.SelectToken "resources[0].properties.sku.name")
+    let capacity = int(jobj.SelectToken "resources[0].properties.sku.capacity")
+    let family = string(jobj.SelectToken "resources[0].properties.sku.family")
+
+    Expect.equal expectedSku      sku      $"Unexpected sku: {sku}"
+    Expect.equal expectedCapacity capacity $"Unexpected capacity: {capacity}"
+    Expect.equal expectedFamily   family   $"Unexpected family: {family}"
+
+let tests = testList "Redis: Sku and Capacity" [
+    test "Standard 250 MB" {
+        let redisCache = redis {
+            name "some-redis-cache"
+            sku Redis.Standard_WithCapacity.``250 MB``
+        }
+        verifySku(redisCache, "Standard", 0, "C")
+    }
+    test "Standard 1 GB" {
+        let redisCache = redis {
+            name "some-redis-cache"
+            sku Redis.Standard_WithCapacity.``1 GB``
+        }
+        verifySku(redisCache, "Standard", 1, "C")
+    }
+    test "Standard 2.5 GB" {
+        let redisCache = redis {
+            name "some-redis-cache"
+            sku Redis.Standard_WithCapacity.``2.5 GB``
+        }
+        verifySku(redisCache, "Standard", 2, "C")
+    }
+    test "Premium 6 GB" {
+        let redisCache = redis {
+            name "some-redis-cache"
+            sku Redis.Premium_WithCapacity.``6 GB``
+        }
+        verifySku(redisCache, "Premium", 1, "P")
+    }
+    test "Premium 13 GB" {
+        let redisCache = redis {
+            name "some-redis-cache"
+            sku Redis.Premium_WithCapacity.``13 GB``
+        }
+        verifySku(redisCache, "Premium", 2, "P")
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Redis.fs" />
     <Compile Include="ServicePlan.fs" />
     <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="Helpers.fs" />


### PR DESCRIPTION
This PR closes #https://dev.azure.com/codat/Codat/_workitems/edit/45947

The changes in this PR are as follows:

* Add support for Redis private endpoints
* Make capacity settings for Redis more explicit

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
