### PR TITLE
Add Sql Server & storage account private endpoint support

### DIFF
--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -4,7 +4,7 @@ module Farmer.Arm.Storage
 open Farmer
 open Farmer.Storage
 
-let storageAccounts = ResourceType ("Microsoft.Storage/storageAccounts", "2019-06-01")
+let storageAccounts = ResourceType ("Microsoft.Storage/storageAccounts", "2022-05-01")
 
 let blobServices = ResourceType ("Microsoft.Storage/storageAccounts/blobServices", "2019-06-01")
 let containers = ResourceType ("Microsoft.Storage/storageAccounts/blobServices/containers", "2018-03-01-preview")
@@ -72,6 +72,7 @@ type StorageAccount =
       NetworkAcls : NetworkRuleSet option
       StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option
       MinTlsVersion : TlsVersion option
+      DnsZoneType : string
       Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceId = storageAccounts.resourceId this.Name.ResourceName
@@ -136,6 +137,7 @@ type StorageAccount =
                         | Some Tls11 -> "TLS1_1"
                         | Some Tls12 -> "TLS1_2"
                         | None -> null
+                       dnsEndpointType = this.DnsZoneType
                     |}
             |}
     interface IPostDeploy with

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -304,7 +304,8 @@ type FunctionsConfig =
                   StaticWebsite = None
                   EnableHierarchicalNamespace = None
                   MinTlsVersion = None
-                  Tags = this.Tags }
+                  Tags = this.Tags
+                  DnsZoneType = "Standard" }
             | _ ->
                 ()
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -57,7 +57,9 @@ type StorageAccountConfig =
       /// Minimum TLS version
       MinTlsVersion : TlsVersion option
       /// Tags to apply to the storage account
-      Tags: Map<string,string> }
+      Tags: Map<string,string> 
+      /// DNS endpoint type
+      DnsZoneType: string }
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = StorageAccount.getConnectionString(this.Name)
     /// Gets the Primary endpoint for static website (if enabled)
@@ -93,6 +95,7 @@ type StorageAccountConfig =
               NetworkAcls = this.NetworkAcls
               StaticWebsite = this.StaticWebsite
               MinTlsVersion = this.MinTlsVersion
+              DnsZoneType = this.DnsZoneType
               Tags = this.Tags }
             for name, access in this.Containers do
                 { Name = name
@@ -194,6 +197,7 @@ type StorageAccountBuilder() =
         IsVersioningEnabled = []
         MinTlsVersion = None
         Tags = Map.empty
+        DnsZoneType = "Standard"
     }
     member _.Run state =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Storage Account name has been set."
@@ -356,8 +360,12 @@ type StorageAccountBuilder() =
     [<CustomOperation "min_tls_version">]
     member _.SetMinTlsVersion(state:StorageAccountConfig, minTlsVersion) =
         { state with MinTlsVersion = Some minTlsVersion }
+    /// Set DNS Endpoint type
+    [<CustomOperation "use_azure_dns_zone">]
+    member _.SetDnsEndpointType(state:StorageAccountConfig) =
+        { state with DnsZoneType = "AzureDnsZone" }
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-
+    
 /// Allow adding storage accounts directly to CDNs
 type EndpointBuilder with
     member this.Origin(state:EndpointConfig, storage:StorageAccountConfig) =

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -490,6 +490,7 @@ type PrivateEndpointBuilder() =
             | _ -> raiseFarmer $"Invalid resource type. Cannot link private endpoint to type %s{resource.ResourceId.Type.Type}"
         { state with PrivateLinkServiceConnection = Some { Resource = outputResource; GroupIds = groupIds; Dependencies = Set.ofList dependencies } }
 
+    [<CustomOperation "link_to_resource">]
     member _.PrivateLinkConnection(state:PrivateEndpointConfig, resource:LinkedResource, subresource:string list, dependencies:ResourceId list) = 
         { state with PrivateLinkServiceConnection = Some { Resource = resource; GroupIds = subresource; Dependencies = Set.ofList dependencies } }
 

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -481,6 +481,16 @@ type PrivateEndpointBuilder() =
             match resource.ResourceId.Type.Type with
             // https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource
             | "Microsoft.Cache/Redis" ->  resource,["redisCache"],[]
+            | "Microsoft.Sql/servers" ->  resource,["sqlServer"],[]
+            | "Microsoft.Storage/storageAccounts" ->
+                resource,
+                [
+                    "blob"; "blob_secondary";
+                    "table"; "table_secondary";
+                    "queue"; "queue_secondary";
+                    "file"; "file_secondary";
+                    "dfs"; "dfs_secondary";
+                ],[]
             | "Microsoft.Web/sites" -> resource,["sites"],[]
             | "Microsoft.Web/sites/slots" -> 
                 match resource.ResourceId.Segments |> List.tryHead with

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -155,7 +155,8 @@ type VmConfig =
                   StaticWebsite = None
                   EnableHierarchicalNamespace = None
                   MinTlsVersion = None
-                  Tags = this.Tags }
+                  Tags = this.Tags
+                  DnsZoneType = "Standard" }
             | Some _
             | None ->
                 ()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -32,9 +32,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-
-
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <!-- Normalize paths to sources in symbols when built in Azure Pipelines -->
@@ -45,11 +42,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
-
-	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
@@ -32,6 +32,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <!-- Normalize paths to sources in symbols when built in Azure Pipelines -->
@@ -42,6 +45,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
+
+	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -452,7 +452,7 @@ let tests = testList "Network Tests" [
         let armPe = resources[0] :?> Arm.Network.PrivateEndpoint
         
         Expect.equal ["sites-slotName"] armPe.GroupIds "private endpoint groupIds should match slot name"
-        Expect.equal (Arm.Web.sites.resourceId (ResourceName "webApp") |> Unmanaged) armPe.Resource "private endpoint resource should match parent site name"
+        Expect.equal (Arm.Web.sites.resourceId (ResourceName "webApp") |> Unmanaged) armPe.Resource "private endpoint should link to correct resource"
     }
     test "Can create private endpoint for Redis" {
         let peConfig = 
@@ -466,6 +466,20 @@ let tests = testList "Network Tests" [
         let armPe = resources[0] :?> Arm.Network.PrivateEndpoint
         
         Expect.equal ["redisCache"] armPe.GroupIds "redisCache"
-        Expect.equal (Arm.Cache.redis.resourceId (ResourceName "redisCacheName") |> Unmanaged) armPe.Resource "private endpoint resource should match parent site name"
+        Expect.equal (Arm.Cache.redis.resourceId (ResourceName "redisCacheName") |> Unmanaged) armPe.Resource "private endpoint should link to correct resource"
+    }
+    test "Can create private endpoint for SqlServer" {
+        let peConfig = 
+          privateEndpoint {
+              name "privateendpoint"
+              subnet (subnets.resourceId "some-subnet" |> Unmanaged |> SubnetReference.create)
+              link_to_resource (Arm.Sql.servers.resourceId(ResourceName "sqlServerName") |> Unmanaged)
+              link_to_private_dns_zone (Farmer.Arm.Dns.zones.resourceId("dnsZone") |> Unmanaged)
+          } :> IBuilder
+        let resources = peConfig.BuildResources Location.NorthEurope
+        let armPe = resources[0] :?> Arm.Network.PrivateEndpoint
+        
+        Expect.equal ["sqlServer"] armPe.GroupIds "sqlServer"
+        Expect.equal (Arm.Sql.servers.resourceId (ResourceName "sqlServerName") |> Unmanaged) armPe.Resource "private endpoint resource should link to correct resource"
     }
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -375,6 +375,7 @@ let tests = testList "Storage Tests" [
             arm { add_resource account } |> getStorageResource
         Expect.equal resource.MinimumTlsVersion "TLS1_2" "Min TLS version is wrong"
     }
+
     test "dnsEndpointType is standard by default" {
         let resource =
             let account = storageAccount {
@@ -387,6 +388,7 @@ let tests = testList "Storage Tests" [
         
         Expect.equal (jobj.SelectToken("resources[0].properties.dnsEndpointType").ToString()) "Standard" "dnsEndpointType should be standard by default"
     }
+    
     test "dnsEndpointType can be set to AzureDnsZone" {
         let resource =
             let account = storageAccount {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -201,7 +201,7 @@ let tests = testList "Storage Tests" [
     test "WebsitePrimaryEndpoint creation" {
         let builder = storageAccount { name "foo" }
 
-        Expect.equal builder.WebsitePrimaryEndpoint.Value "reference(resourceId('Microsoft.Storage/storageAccounts', 'foo'), '2019-06-01').primaryEndpoints.web" "Zone names are not fixed and should be related to a storage account name"
+        Expect.equal builder.WebsitePrimaryEndpoint.Value "reference(resourceId('Microsoft.Storage/storageAccounts', 'foo'), '2022-05-01').primaryEndpoints.web" "Zone names are not fixed and should be related to a storage account name"
     }
     test "Creates different SKU kinds correctly" {
         let account = storageAccount { name "storage"; sku (Blobs (BlobReplication.LRS, Some DefaultAccessTier.Hot)) }
@@ -374,6 +374,31 @@ let tests = testList "Storage Tests" [
             }
             arm { add_resource account } |> getStorageResource
         Expect.equal resource.MinimumTlsVersion "TLS1_2" "Min TLS version is wrong"
+    }
+    test "dnsEndpointType is standard by default" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.dnsEndpointType").ToString()) "Standard" "dnsEndpointType should be standard by default"
+    }
+    test "dnsEndpointType can be set to AzureDnsZone" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                use_azure_dns_zone
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.dnsEndpointType").ToString()) "AzureDnsZone" "dnsEndpointType should AzureDnsZone"
     }
 
     test "Must set a storage account name" {

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -5,12 +5,14 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsuperdata",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -5,12 +5,14 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacgriddevprac",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -83,12 +83,14 @@
       "type": "Microsoft.Sql/servers/elasticPools"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerstorage1979",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },
@@ -223,12 +225,14 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerfuncs1979storage",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },
@@ -409,12 +413,12 @@
         "isHttpAllowed": true,
         "isHttpsAllowed": true,
         "optimizationType": "GeneralWebDelivery",
-        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2019-06-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
+        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
         "origins": [
           {
             "name": "origin",
             "properties": {
-              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2019-06-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
+              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
             }
           }
         ],
@@ -780,12 +784,14 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "dockerfuncstorage",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -20,7 +20,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2019-06-01').primaryEndpoints.blob]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2022-05-01').primaryEndpoints.blob]"
           }
         },
         "hardwareProfile": {
@@ -144,12 +144,14 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsvmstorage",
-      "properties": {},
+      "properties": {
+        "dnsEndpointType": "Standard"
+      },
       "sku": {
         "name": "Standard_LRS"
       },


### PR DESCRIPTION
The changes in this PR are as follows:

* Add SqlServer private endpoint support
* Add support for advanced config of private endpoints which allows storage account private endpoints.
* Add support for dnsEndpointType in storageAccount which allows you to create 5000 storage accounts.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

