### PR TITLE
Add support for disabling public network access to storage accounts

### DIFF
--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -73,6 +73,7 @@ type StorageAccount =
       StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option
       MinTlsVersion : TlsVersion option
       DnsZoneType : string
+      DisablePublicNetworkAccess: FeatureFlag
       Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceId = storageAccounts.resourceId this.Name.ResourceName
@@ -138,6 +139,10 @@ type StorageAccount =
                         | Some Tls12 -> "TLS1_2"
                         | None -> null
                        dnsEndpointType = this.DnsZoneType
+                       publicNetworkAccess =
+                         match this.DisablePublicNetworkAccess with
+                           | FeatureFlag.Disabled -> "Enabled"
+                           | FeatureFlag.Enabled -> "Disabled"
                     |}
             |}
     interface IPostDeploy with

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -305,7 +305,8 @@ type FunctionsConfig =
                   EnableHierarchicalNamespace = None
                   MinTlsVersion = None
                   Tags = this.Tags
-                  DnsZoneType = "Standard" }
+                  DnsZoneType = "Standard"
+                  DisablePublicNetworkAccess = FeatureFlag.Disabled }
             | _ ->
                 ()
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -391,7 +391,7 @@ type StorageAccountBuilder() =
     /// Disable public network access, all access must be through a private endpoint.
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state:StorageAccountConfig) =
-        { state with DisablePublicNetworkAccess = FeatureFlag.Disabled }
+        { state with DisablePublicNetworkAccess = FeatureFlag.Enabled }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -364,7 +364,7 @@ type StorageAccountBuilder() =
             { state with
                 NetworkAcls =
                     { existingAcl with
-                        Bypass = set bypass
+                        Bypass = Set.union (set bypass) existingAcl.Bypass
                     } |> Some
             }
     /// Adds a set of CORS rules to the storage account.

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -348,6 +348,25 @@ type StorageAccountBuilder() =
                         IpRules = allowIp :: existingAcl.IpRules
                     } |> Some
             }
+    /// Restrict access to this storage account to the private endpoints and azure services.
+    [<CustomOperation "restrict_to_azure_services">]
+    member _.RestrictToAzureServices(state:StorageAccountConfig, bypass:NetworkRuleSetBypass list) =
+        match state.NetworkAcls with
+        | None ->
+            { state with
+                NetworkAcls =
+                    { Bypass = set bypass
+                      VirtualNetworkRules = []
+                      IpRules = []
+                      DefaultAction = RuleAction.Deny } |> Some
+            }
+        | Some existingAcl ->
+            { state with
+                NetworkAcls =
+                    { existingAcl with
+                        Bypass = set bypass
+                    } |> Some
+            }
     /// Adds a set of CORS rules to the storage account.
     [<CustomOperation "add_cors_rules">]
     member _.AddCorsRules(state:StorageAccountConfig, rules) =

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -391,7 +391,14 @@ type StorageAccountBuilder() =
     /// Disable public network access, all access must be through a private endpoint.
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state:StorageAccountConfig) =
-        { state with DisablePublicNetworkAccess = FeatureFlag.Enabled }
+        { state with
+            DisablePublicNetworkAccess = FeatureFlag.Enabled
+            NetworkAcls =
+                { Bypass = set []
+                  VirtualNetworkRules = []
+                  IpRules = []
+                  DefaultAction = RuleAction.Deny } |> Some
+        }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -372,24 +372,14 @@ type StorageAccountBuilder() =
     /// Disable public network access, all access must be through a private endpoint.
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state:StorageAccountConfig) =
-        let newState = 
-          match state.NetworkAcls with
-            | None ->
-                { state with
-                    NetworkAcls =
-                        { Bypass = set [ NetworkRuleSetBypass.AzureServices ]
-                          VirtualNetworkRules = []
-                          IpRules = [ ]
-                          DefaultAction = RuleAction.Deny } |> Some
-                }
-            | Some existingAcl ->
-                { state with
-                    NetworkAcls =
-                        { existingAcl with
-                            DefaultAction = RuleAction.Deny
-                        } |> Some
-                }
-        { newState with DisablePublicNetworkAccess = FeatureFlag.Enabled  }
+        { state with
+              NetworkAcls =
+                  { Bypass = set [ NetworkRuleSetBypass.AzureServices ]
+                    VirtualNetworkRules = []
+                    IpRules = [ ]
+                    DefaultAction = RuleAction.Deny } |> Some
+              DisablePublicNetworkAccess = FeatureFlag.Enabled
+        }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -372,25 +372,7 @@ type StorageAccountBuilder() =
     /// Disable public network access, all access must be through a private endpoint.
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state:StorageAccountConfig) =
-        { state with
-              NetworkAcls =
-                  { Bypass = set []
-                    VirtualNetworkRules = []
-                    IpRules = []
-                    DefaultAction = RuleAction.Deny } |> Some
-              DisablePublicNetworkAccess = FeatureFlag.Enabled
-        }
-
-    [<CustomOperation "disable_public_network_access">]
-    member _.DisablePublicNetworkAccess(state:StorageAccountConfig, bypass:NetworkRuleSetBypass list) =
-        { state with
-              NetworkAcls =
-                  { Bypass = set bypass
-                    VirtualNetworkRules = []
-                    IpRules = []
-                    DefaultAction = RuleAction.Deny } |> Some
-              DisablePublicNetworkAccess = FeatureFlag.Enabled
-        }
+        { state with DisablePublicNetworkAccess = FeatureFlag.Disabled }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -394,7 +394,7 @@ type StorageAccountBuilder() =
         { state with
             DisablePublicNetworkAccess = FeatureFlag.Enabled
             NetworkAcls =
-                { Bypass = set []
+                { Bypass = set [ NetworkRuleSetBypass.None ]
                   VirtualNetworkRules = []
                   IpRules = []
                   DefaultAction = RuleAction.Deny } |> Some

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -374,9 +374,20 @@ type StorageAccountBuilder() =
     member _.DisablePublicNetworkAccess(state:StorageAccountConfig) =
         { state with
               NetworkAcls =
-                  { Bypass = set [ NetworkRuleSetBypass.AzureServices ]
+                  { Bypass = set []
                     VirtualNetworkRules = []
-                    IpRules = [ ]
+                    IpRules = []
+                    DefaultAction = RuleAction.Deny } |> Some
+              DisablePublicNetworkAccess = FeatureFlag.Enabled
+        }
+
+    [<CustomOperation "disable_public_network_access">]
+    member _.DisablePublicNetworkAccess(state:StorageAccountConfig, bypass:NetworkRuleSetBypass list) =
+        { state with
+              NetworkAcls =
+                  { Bypass = set bypass
+                    VirtualNetworkRules = []
+                    IpRules = []
                     DefaultAction = RuleAction.Deny } |> Some
               DisablePublicNetworkAccess = FeatureFlag.Enabled
         }

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -156,7 +156,8 @@ type VmConfig =
                   EnableHierarchicalNamespace = None
                   MinTlsVersion = None
                   Tags = this.Tags
-                  DnsZoneType = "Standard" }
+                  DnsZoneType = "Standard"
+                  DisablePublicNetworkAccess = FeatureFlag.Disabled }
             | Some _
             | None ->
                 ()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.6</Version>
+    <Version>1.7.7</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -432,6 +432,7 @@ let tests = testList "Storage Tests" [
         let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
         
         Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "public network access should be disabled"
+        Expect.equal (jobj.SelectToken("resources[0].properties.networkAcls.defaultAction").ToString()) "Deny" "network acl should deny traffic when disabling public network access"
     }
 
     test "restrict_to_azure_services adds correct network acl" {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -440,7 +440,8 @@ let tests = testList "Storage Tests" [
         let resource =
             let account = storageAccount {
                 name "mystorage123"
-                restrict_to_azure_services [Farmer.Arm.Storage.NetworkRuleSetBypass.AzureServices; Farmer.Arm.Storage.NetworkRuleSetBypass.Metrics]
+                restrict_to_azure_services [Farmer.Arm.Storage.NetworkRuleSetBypass.AzureServices]
+                restrict_to_azure_services [Farmer.Arm.Storage.NetworkRuleSetBypass.Metrics]
             }
             arm { add_resource account }
 

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -433,6 +433,7 @@ let tests = testList "Storage Tests" [
         
         Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "public network access should be disabled"
         Expect.equal (jobj.SelectToken("resources[0].properties.networkAcls.defaultAction").ToString()) "Deny" "network acl should deny traffic when disabling public network access"
+        Expect.equal (jobj.SelectToken("resources[0].properties.networkAcls.bypass").ToString()) "None" "network acl should not allow bypass by default"
     }
 
     test "restrict_to_azure_services adds correct network acl" {

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -11,7 +11,8 @@
       "location": "northeurope",
       "name": "isaacsuperdata",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -11,7 +11,8 @@
       "location": "northeurope",
       "name": "isaacgriddevprac",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -89,7 +89,8 @@
       "location": "northeurope",
       "name": "farmerstorage1979",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"
@@ -231,7 +232,8 @@
       "location": "northeurope",
       "name": "farmerfuncs1979storage",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"
@@ -790,7 +792,8 @@
       "location": "northeurope",
       "name": "dockerfuncstorage",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -150,7 +150,8 @@
       "location": "northeurope",
       "name": "isaacsvmstorage",
       "properties": {
-        "dnsEndpointType": "Standard"
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
       },
       "sku": {
         "name": "Standard_LRS"


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adds a new `disable_public_network_access` operator that disables public network access to storage accounts.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
