### PR TITLE
Add support for storage account security settings

### DIFF
--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -74,6 +74,7 @@ type StorageAccount =
       MinTlsVersion : TlsVersion option
       DnsZoneType : string
       DisablePublicNetworkAccess: FeatureFlag
+      DisableBlobPublicAccess: FeatureFlag
       Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceId = storageAccounts.resourceId this.Name.ResourceName
@@ -143,6 +144,10 @@ type StorageAccount =
                          match this.DisablePublicNetworkAccess with
                            | FeatureFlag.Disabled -> "Enabled"
                            | FeatureFlag.Enabled -> "Disabled"
+                       allowBlobPublicAccess = 
+                         match this.DisableBlobPublicAccess with
+                           | FeatureFlag.Disabled -> "true"
+                           | FeatureFlag.Enabled -> "false"
                     |}
             |}
     interface IPostDeploy with

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -75,6 +75,8 @@ type StorageAccount =
       DnsZoneType : string
       DisablePublicNetworkAccess: FeatureFlag
       DisableBlobPublicAccess: FeatureFlag
+      DisableSharedKeyAccess : FeatureFlag 
+      DefaultToOAuthAuthentication : FeatureFlag
       Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceId = storageAccounts.resourceId this.Name.ResourceName
@@ -148,6 +150,14 @@ type StorageAccount =
                          match this.DisableBlobPublicAccess with
                            | FeatureFlag.Disabled -> "true"
                            | FeatureFlag.Enabled -> "false"
+                       allowSharedKeyAccess = 
+                         match this.DisableSharedKeyAccess with
+                           | FeatureFlag.Disabled -> "true"
+                           | FeatureFlag.Enabled -> "false"
+                       defaultToOAuthAuthentication = 
+                         match this.DefaultToOAuthAuthentication with
+                           | FeatureFlag.Disabled -> "false"
+                           | FeatureFlag.Enabled -> "true"
                     |}
             |}
     interface IPostDeploy with

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -306,7 +306,8 @@ type FunctionsConfig =
                   MinTlsVersion = None
                   Tags = this.Tags
                   DnsZoneType = "Standard"
-                  DisablePublicNetworkAccess = FeatureFlag.Disabled }
+                  DisablePublicNetworkAccess = FeatureFlag.Disabled
+                  DisableBlobPublicAccess = FeatureFlag.Disabled }
             | _ ->
                 ()
 

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -307,7 +307,9 @@ type FunctionsConfig =
                   Tags = this.Tags
                   DnsZoneType = "Standard"
                   DisablePublicNetworkAccess = FeatureFlag.Disabled
-                  DisableBlobPublicAccess = FeatureFlag.Disabled }
+                  DisableBlobPublicAccess = FeatureFlag.Disabled
+                  DisableSharedKeyAccess = FeatureFlag.Disabled
+                  DefaultToOAuthAuthentication = FeatureFlag.Disabled }
             | _ ->
                 ()
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -63,7 +63,11 @@ type StorageAccountConfig =
       /// Disable Public Network Acccess
       DisablePublicNetworkAccess: FeatureFlag
       /// Disable blob public access
-      DisableBlobPublicAccess : FeatureFlag }
+      DisableBlobPublicAccess : FeatureFlag 
+      /// Disable Shared Key Access
+      DisableSharedKeyAccess : FeatureFlag 
+      /// Default to Azure Active Directory authorization in the Azure portal
+      DefaultToOAuthAuthentication : FeatureFlag }
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = StorageAccount.getConnectionString(this.Name)
     /// Gets the Primary endpoint for static website (if enabled)
@@ -102,6 +106,8 @@ type StorageAccountConfig =
               DnsZoneType = this.DnsZoneType
               DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
               DisableBlobPublicAccess = this.DisableBlobPublicAccess
+              DisableSharedKeyAccess = this.DisableSharedKeyAccess
+              DefaultToOAuthAuthentication = this.DefaultToOAuthAuthentication
               Tags = this.Tags }
             for name, access in this.Containers do
                 { Name = name
@@ -206,6 +212,8 @@ type StorageAccountBuilder() =
         DnsZoneType = "Standard"
         DisablePublicNetworkAccess = FeatureFlag.Disabled
         DisableBlobPublicAccess = FeatureFlag.Disabled
+        DisableSharedKeyAccess = FeatureFlag.Disabled
+        DefaultToOAuthAuthentication = FeatureFlag.Disabled
         }
     member _.Run state =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Storage Account name has been set."
@@ -411,6 +419,22 @@ type StorageAccountBuilder() =
     [<CustomOperation "disable_blob_public_access">]
     member _.DisableBlobPublicAccess(state:StorageAccountConfig, flag:FeatureFlag) =
         { state with DisableBlobPublicAccess = flag }
+
+    /// Disable shared key access
+    [<CustomOperation "disable_shared_key_access">]
+    member _.DisableSharedKeyAccess(state:StorageAccountConfig) =
+        { state with DisableSharedKeyAccess = FeatureFlag.Enabled }
+    [<CustomOperation "disable_shared_key_access">]
+    member _.DisableSharedKeyAccess(state:StorageAccountConfig, flag:FeatureFlag) =
+        { state with DisableSharedKeyAccess = flag }
+
+    /// Default to Azure Active Directory authorization in the Azure portal
+    [<CustomOperation "default_to_oauth_authentication">]
+    member _.DefaultToOAuthAuthentication(state:StorageAccountConfig) =
+        { state with DefaultToOAuthAuthentication = FeatureFlag.Enabled }
+    [<CustomOperation "default_to_oauth_authentication">]
+    member _.DefaultToOAuthAuthentication(state:StorageAccountConfig, flag:FeatureFlag) =
+        { state with DefaultToOAuthAuthentication = flag }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -61,7 +61,9 @@ type StorageAccountConfig =
       /// DNS endpoint type
       DnsZoneType: string
       /// Disable Public Network Acccess
-      DisablePublicNetworkAccess: FeatureFlag }
+      DisablePublicNetworkAccess: FeatureFlag
+      /// Disable blob public access
+      DisableBlobPublicAccess : FeatureFlag }
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = StorageAccount.getConnectionString(this.Name)
     /// Gets the Primary endpoint for static website (if enabled)
@@ -99,6 +101,7 @@ type StorageAccountConfig =
               MinTlsVersion = this.MinTlsVersion
               DnsZoneType = this.DnsZoneType
               DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
+              DisableBlobPublicAccess = this.DisableBlobPublicAccess
               Tags = this.Tags }
             for name, access in this.Containers do
                 { Name = name
@@ -202,6 +205,7 @@ type StorageAccountBuilder() =
         Tags = Map.empty
         DnsZoneType = "Standard"
         DisablePublicNetworkAccess = FeatureFlag.Disabled
+        DisableBlobPublicAccess = FeatureFlag.Disabled
         }
     member _.Run state =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Storage Account name has been set."
@@ -399,6 +403,14 @@ type StorageAccountBuilder() =
                   IpRules = []
                   DefaultAction = RuleAction.Deny } |> Some
         }
+
+    /// Disable blob public access
+    [<CustomOperation "disable_blob_public_access">]
+    member _.DisableBlobPublicAccess(state:StorageAccountConfig) =
+        { state with DisableBlobPublicAccess = FeatureFlag.Enabled }
+    [<CustomOperation "disable_blob_public_access">]
+    member _.DisableBlobPublicAccess(state:StorageAccountConfig, flag:FeatureFlag) =
+        { state with DisableBlobPublicAccess = flag }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -414,26 +414,20 @@ type StorageAccountBuilder() =
 
     /// Disable blob public access
     [<CustomOperation "disable_blob_public_access">]
-    member _.DisableBlobPublicAccess(state:StorageAccountConfig) =
-        { state with DisableBlobPublicAccess = FeatureFlag.Enabled }
-    [<CustomOperation "disable_blob_public_access">]
-    member _.DisableBlobPublicAccess(state:StorageAccountConfig, flag:FeatureFlag) =
+    member _.DisableBlobPublicAccess(state:StorageAccountConfig, ?flag:FeatureFlag) =
+        let flag = defaultArg flag FeatureFlag.Enabled
         { state with DisableBlobPublicAccess = flag }
 
     /// Disable shared key access
     [<CustomOperation "disable_shared_key_access">]
-    member _.DisableSharedKeyAccess(state:StorageAccountConfig) =
-        { state with DisableSharedKeyAccess = FeatureFlag.Enabled }
-    [<CustomOperation "disable_shared_key_access">]
-    member _.DisableSharedKeyAccess(state:StorageAccountConfig, flag:FeatureFlag) =
+    member _.DisableSharedKeyAccess(state:StorageAccountConfig, ?flag:FeatureFlag) =
+        let flag = defaultArg flag FeatureFlag.Enabled
         { state with DisableSharedKeyAccess = flag }
 
     /// Default to Azure Active Directory authorization in the Azure portal
     [<CustomOperation "default_to_oauth_authentication">]
-    member _.DefaultToOAuthAuthentication(state:StorageAccountConfig) =
-        { state with DefaultToOAuthAuthentication = FeatureFlag.Enabled }
-    [<CustomOperation "default_to_oauth_authentication">]
-    member _.DefaultToOAuthAuthentication(state:StorageAccountConfig, flag:FeatureFlag) =
+    member _.DefaultToOAuthAuthentication(state:StorageAccountConfig, ?flag:FeatureFlag) =
+        let flag = defaultArg flag FeatureFlag.Enabled
         { state with DefaultToOAuthAuthentication = flag }
 
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -158,7 +158,9 @@ type VmConfig =
                   Tags = this.Tags
                   DnsZoneType = "Standard"
                   DisablePublicNetworkAccess = FeatureFlag.Disabled
-                  DisableBlobPublicAccess = FeatureFlag.Disabled }
+                  DisableBlobPublicAccess = FeatureFlag.Disabled
+                  DisableSharedKeyAccess = FeatureFlag.Disabled
+                  DefaultToOAuthAuthentication = FeatureFlag.Disabled }
             | Some _
             | None ->
                 ()

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -157,7 +157,8 @@ type VmConfig =
                   MinTlsVersion = None
                   Tags = this.Tags
                   DnsZoneType = "Standard"
-                  DisablePublicNetworkAccess = FeatureFlag.Disabled }
+                  DisablePublicNetworkAccess = FeatureFlag.Disabled
+                  DisableBlobPublicAccess = FeatureFlag.Disabled }
             | Some _
             | None ->
                 ()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.7</Version>
+    <Version>1.7.8</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -495,4 +495,88 @@ let tests = testList "Storage Tests" [
         
         Expect.equal (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString()) "true" "blob public access should be enabled"
     }
+
+    test "Shared key access is enabled by default" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString()) "true" "shared key access should be enabled by default"
+    }
+
+    test "Shared key access can be disabled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                disable_shared_key_access
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString()) "false" "shared key access should be disabled"
+    }
+
+    test "Shared key access can be toggled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                disable_shared_key_access
+                disable_shared_key_access FeatureFlag.Disabled
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString()) "true" "shared key access should be enabled"
+    }
+
+    test "Default to OAuth is enabled by default" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.defaultToOAuthAuthentication").ToString()) "false" "default to OAuth should be disabled by default"
+    }
+
+    test "Default to OAuth can be disabled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                default_to_oauth_authentication
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.defaultToOAuthAuthentication").ToString()) "true" "default to OAuth should be enabled"
+    }
+
+    test "Default to OAuth can be toggled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                default_to_oauth_authentication
+                default_to_oauth_authentication FeatureFlag.Disabled
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.defaultToOAuthAuthentication").ToString()) "false" "default to OAuth should be disabled"
+    }
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -453,4 +453,46 @@ let tests = testList "Storage Tests" [
         Expect.isEmpty (jobj.SelectToken("resources[0].properties.networkAcls.ipRules").Values<string>()) "network acl should not define ip restrictions"
         Expect.isEmpty (jobj.SelectToken("resources[0].properties.networkAcls.virtualNetworkRules").Values<string>()) "network acl should not define vnet restrictions"
     }
+
+    test "Blob public access is enabled by default" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString()) "true" "blob public access should be enabled by default"
+    }
+
+    test "Blob public access can be disabled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                disable_blob_public_access
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString()) "false" "blob public access should be disabled"
+    }
+
+    test "Blob public access can be toggled" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
+                disable_blob_public_access
+                disable_blob_public_access FeatureFlag.Disabled
+            }
+            arm { add_resource account }
+
+        let jsn = resource.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString()) "true" "blob public access should be enabled"
+    }
 ]

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -11,6 +11,7 @@
       "location": "northeurope",
       "name": "isaacsuperdata",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -12,6 +12,8 @@
       "name": "isaacsuperdata",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -11,6 +11,7 @@
       "location": "northeurope",
       "name": "isaacgriddevprac",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -12,6 +12,8 @@
       "name": "isaacgriddevprac",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -90,6 +90,8 @@
       "name": "farmerstorage1979",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },
@@ -234,6 +236,8 @@
       "name": "farmerfuncs1979storage",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },
@@ -795,6 +799,8 @@
       "name": "dockerfuncstorage",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -89,6 +89,7 @@
       "location": "northeurope",
       "name": "farmerstorage1979",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },
@@ -232,6 +233,7 @@
       "location": "northeurope",
       "name": "farmerfuncs1979storage",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },
@@ -792,6 +794,7 @@
       "location": "northeurope",
       "name": "dockerfuncstorage",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -150,6 +150,7 @@
       "location": "northeurope",
       "name": "isaacsvmstorage",
       "properties": {
+        "allowBlobPublicAccess": "true",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -151,6 +151,8 @@
       "name": "isaacsvmstorage",
       "properties": {
         "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
         "dnsEndpointType": "Standard",
         "publicNetworkAccess": "Enabled"
       },


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adds support for disabling blob public access at account level
* Adds support for disabling shared access key
* Adds support for defaulting to OAuth (AAD) authentication when accessing data in the portal

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
