### PR TITLE
Add support for SCM IP restrictions

### DIFF
--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -240,6 +240,7 @@ type Site =
         LinkToSubnet: SubnetReference option
         VirtualApplications: Map<string, VirtualApplication>
         PostDeployActions: (string -> Result<string, string> option) list
+        ApplyIPSecurityRestrictionsToScm: bool
     }
 
     /// Shorthand for SiteType.ResourceType
@@ -400,6 +401,7 @@ type Site =
                                                 priority = index + 1
                                             |})
                                         |> box
+                                scmIpSecurityRestrictionsUseMain = this.ApplyIPSecurityRestrictionsToScm
                                 pythonVersion = this.PythonVersion |> Option.toObj
                                 http20Enabled = this.HTTP20Enabled |> Option.toNullable
                                 webSocketsEnabled = this.WebSocketsEnabled |> Option.toNullable

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -467,6 +467,7 @@ type FunctionsBuilder() =
                     IpSecurityRestrictions = []
                     IntegratedSubnet = None
                     PrivateEndpoints = Set.empty
+                    ApplyIPSecurityRestrictionsToScm = false
                 }
             StorageAccount =
                 derived (fun config ->

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -348,6 +348,7 @@ type FunctionsConfig =
                         WorkerProcess = this.CommonWebConfig.WorkerProcess
                         HealthCheckPath = this.CommonWebConfig.HealthCheckPath
                         IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions
+                        ApplyIPSecurityRestrictionsToScm = this.CommonWebConfig.ApplyIPSecurityRestrictionsToScm
                         LinkToSubnet = this.CommonWebConfig.IntegratedSubnet
                         VirtualApplications = Map []
                     }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -746,6 +746,7 @@ type WebAppConfig =
                             |> Option.map (fun (path, slot) -> path, ZipDeploy.ZipDeployTarget.WebApp, slot)
                         HealthCheckPath = this.CommonWebConfig.HealthCheckPath
                         IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions
+                        ApplyIPSecurityRestrictionsToScm = this.CommonWebConfig.ApplyIPSecurityRestrictionsToScm
                         LinkToSubnet = this.CommonWebConfig.IntegratedSubnet
                         PostDeployActions = []
                         VirtualApplications = this.VirtualApplications

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -106,6 +106,7 @@ type SlotConfig =
         Tags: Map<string, string>
         Dependencies: ResourceId Set
         IpSecurityRestrictions: IpSecurityRestriction list
+        ApplyIPSecurityRestrictionsToScm: bool
     }
 
     member this.ToSite(owner: Arm.Web.Site) =
@@ -208,6 +209,7 @@ type SlotBuilder() =
             Tags = Map.empty
             Dependencies = Set.empty
             IpSecurityRestrictions = []
+            ApplyIPSecurityRestrictionsToScm = false
         }
 
     [<CustomOperation "name">]
@@ -302,33 +304,41 @@ type SlotBuilder() =
 
     /// Add Allowed ip for ip security restrictions
     [<CustomOperation "add_allowed_ip_restriction">]
-    member _.AllowIp(state, name, cidr: IPAddressCidr) : SlotConfig =
+    member _.AllowIp(state, name, cidr: IPAddressCidr, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         { state with
             IpSecurityRestrictions = state.IpSecurityRestrictions @ [ IpSecurityRestriction.Create name cidr Allow ]
+            ApplyIPSecurityRestrictionsToScm = applyToScm
         }
 
-    member this.AllowIp(state, name, ip: Net.IPAddress) : SlotConfig =
+    member this.AllowIp(state, name, ip: Net.IPAddress, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         let cidr = { Address = ip; Prefix = 32 }
-        this.AllowIp(state, name, cidr)
+        this.AllowIp(state, name, cidr, applyToScm)
 
-    member this.AllowIp(state, name, ip: string) : SlotConfig =
+    member this.AllowIp(state, name, ip: string, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         let cidr = IPAddressCidr.parse ip
-        this.AllowIp(state, name, cidr)
+        this.AllowIp(state, name, cidr, applyToScm)
 
     /// Add Denied ip for ip security restrictions
     [<CustomOperation "add_denied_ip_restriction">]
-    member _.DenyIp(state, name, cidr: IPAddressCidr) : SlotConfig =
+    member _.DenyIp(state, name, cidr: IPAddressCidr, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         { state with
             IpSecurityRestrictions = state.IpSecurityRestrictions @ [ IpSecurityRestriction.Create name cidr Deny ]
+            ApplyIPSecurityRestrictionsToScm = applyToScm
         }
 
-    member this.DenyIp(state, name, ip: Net.IPAddress) : SlotConfig =
+    member this.DenyIp(state, name, ip: Net.IPAddress, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         let cidr = { Address = ip; Prefix = 32 }
-        this.DenyIp(state, name, cidr)
+        this.DenyIp(state, name, cidr, applyToScm)
 
-    member this.DenyIp(state, name, ip: string) : SlotConfig =
+    member this.DenyIp(state, name, ip: string, ?applyToScm:bool) : SlotConfig =
+        let applyToScm = defaultArg applyToScm false
         let cidr = IPAddressCidr.parse ip
-        this.DenyIp(state, name, cidr)
+        this.DenyIp(state, name, cidr, applyToScm)
 
     interface ITaggable<SlotConfig> with
         member _.Add state tags =
@@ -413,6 +423,7 @@ type CommonWebConfig =
         IpSecurityRestrictions: IpSecurityRestriction list
         IntegratedSubnet: SubnetReference option
         PrivateEndpoints: (SubnetReference * string option) Set
+        ApplyIPSecurityRestrictionsToScm: bool
     }
 
     member this.Validate() =
@@ -953,6 +964,7 @@ type WebAppBuilder() =
                     IpSecurityRestrictions = []
                     IntegratedSubnet = None
                     PrivateEndpoints = Set.empty
+                    ApplyIPSecurityRestrictionsToScm = false
                 }
             WorkerSize = Small
             WorkerCount = 1
@@ -1647,26 +1659,32 @@ module Extensions =
 
         /// Add Allowed ip for ip security restrictions
         [<CustomOperation "add_allowed_ip_restriction">]
-        member this.AllowIp(state: 'T, name, ip: IPAddressCidr) =
+        member this.AllowIp(state: 'T, name, ip: IPAddressCidr, ?applyToScm:bool) =
+            let applyToScm = defaultArg applyToScm false
             this.Map state (fun x ->
                 { x with
                     IpSecurityRestrictions = IpSecurityRestriction.Create name ip Allow :: x.IpSecurityRestrictions
+                    ApplyIPSecurityRestrictionsToScm = applyToScm
                 })
 
-        member this.AllowIp(state: 'T, name, ip: string) =
+        member this.AllowIp(state: 'T, name, ip: string, ?applyToScm:bool) =
+            let applyToScm = defaultArg applyToScm false
             let ip = IPAddressCidr.parse ip
 
             this.Map state (fun x ->
                 { x with
                     IpSecurityRestrictions = IpSecurityRestriction.Create name ip Allow :: x.IpSecurityRestrictions
+                    ApplyIPSecurityRestrictionsToScm = applyToScm
                 })
 
         /// Add Denied ip for ip security restrictions
         [<CustomOperation "add_denied_ip_restriction">]
-        member this.DenyIp(state: 'T, name, ip) =
+        member this.DenyIp(state: 'T, name, ip, ?applyToScm:bool) =
+            let applyToScm = defaultArg applyToScm false
             this.Map state (fun x ->
                 { x with
                     IpSecurityRestrictions = IpSecurityRestriction.Create name ip Deny :: x.IpSecurityRestrictions
+                    ApplyIPSecurityRestrictionsToScm = applyToScm
                 })
 
         /// Integrate this app with a virtual network subnet

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -7,7 +7,6 @@
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
     <Authors>Isaac Abraham and contributors</Authors>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!-- Build settings -->
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -43,10 +42,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
-	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.8</Version>
+    <Version>1.7.9</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
     <Authors>Isaac Abraham and contributors</Authors>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!-- Build settings -->
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -42,6 +43,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
+	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -890,4 +890,32 @@ let tests =
                 let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection>
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
+            test "IP restrictions are not applied to SCM site by default" {
+                let ip = IPAddressCidr.parse "1.2.3.4/32"
+
+                let resources =
+                    functions {
+                        name "test"
+                        add_allowed_ip_restriction "test-rule" ip
+                    }
+                    |> getResources
+
+                let site = resources |> getResource<Web.Site> |> List.head
+
+                Expect.isFalse site.ApplyIPSecurityRestrictionsToScm "ip security restrictions should not be applied to scm by default"
+            }
+            test "IP restrictions can be applied to SCM site" {
+                let ip = IPAddressCidr.parse "1.2.3.4/32"
+
+                let resources =
+                    functions {
+                        name "test"
+                        add_allowed_ip_restriction "test-rule" ip true
+                    }
+                    |> getResources
+
+                let site = resources |> getResource<Web.Site> |> List.head
+
+                Expect.isTrue site.ApplyIPSecurityRestrictionsToScm "ip security restrictions should be applied to scm site"
+            }
         ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -1911,4 +1911,32 @@ let tests =
                 Expect.equal site.Name.Value "webapp/deployment" "site name was not as expected"
                 Expect.hasLength site.PostDeployActions 1 "no custom post deploy actions found"
             }
+            test "IP restrictions are not applied to SCM site by default" {
+                let ip = IPAddressCidr.parse "1.2.3.4/32"
+
+                let resources =
+                    webApp {
+                        name "test"
+                        add_allowed_ip_restriction "test-rule" ip
+                    }
+                    |> getResources
+
+                let site = resources |> getResource<Web.Site> |> List.head
+
+                Expect.isFalse site.ApplyIPSecurityRestrictionsToScm "ip security restrictions should not be applied to scm by default"
+            }
+            test "IP restrictions can be applied to SCM site" {
+                let ip = IPAddressCidr.parse "1.2.3.4/32"
+
+                let resources =
+                    webApp {
+                        name "test"
+                        add_allowed_ip_restriction "test-rule" ip true
+                    }
+                    |> getResources
+
+                let site = resources |> getResource<Web.Site> |> List.head
+
+                Expect.isTrue site.ApplyIPSecurityRestrictionsToScm "ip security restrictions should be applied to scm site"
+            }
         ]

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -70,7 +70,8 @@
               "name": "CURRENT_STACK",
               "value": "dotnetcore"
             }
-          ]
+          ],
+          "scmIpSecurityRestrictionsUseMain": false
         }
       },
       "tags": {},

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -204,7 +204,8 @@
               "name": "CURRENT_STACK",
               "value": "dotnetcore"
             }
-          ]
+          ],
+          "scmIpSecurityRestrictionsUseMain": false
         }
       },
       "tags": {},
@@ -315,7 +316,8 @@
             }
           ],
           "connectionStrings": [],
-          "metadata": []
+          "metadata": [],
+          "scmIpSecurityRestrictionsUseMain": false
         }
       },
       "tags": {},
@@ -868,7 +870,8 @@
             }
           ],
           "connectionStrings": [],
-          "metadata": []
+          "metadata": [],
+          "scmIpSecurityRestrictionsUseMain": false
         }
       },
       "tags": {},


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add support for SCM IP restrictions

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let func = functions env {
    name (env.standardizedResourceName ("netsegfunctest",["funcs"]))
    // ...

    // add restriction only to main site
    add_allowed_ip_restriction "codat_private" "10.0.0.0/8"

    // add restriction to scm site
    add_allowed_ip_restriction "codat_private" "10.0.0.0/8" true
}

```
