### PR TITLE
Add support for Net 7.0

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -71,6 +71,7 @@ type Runtime =
     static member Java8Tomcat85 = Java(Java8, JavaHost.Tomcat85)
     static member DotNet50 = DotNet "5.0"
     static member DotNet60 = DotNet "6.0"
+    static member DotNet70 = DotNet "7.0"
     static member AspNet47 = AspNet "4.0"
     static member AspNet35 = AspNet "2.0"
     static member Python27 = Python("2.7", "2.7")
@@ -705,7 +706,7 @@ type WebAppConfig =
                             match this.Runtime with
                             | AspNet version
                             | DotNet ("5.0" as version)
-                            | DotNet ("6.0" as version) -> Some $"v{version}"
+                            | DotNet version -> Some $"v{version}"
                             | _ -> None
                         JavaVersion =
                             match this.Runtime, this.CommonWebConfig.OperatingSystem with

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -670,6 +670,18 @@ let tests =
                 Expect.equal site.Metadata.Head ("CURRENT_STACK", "dotnet") "Stack should be dotnet"
             }
 
+            test "Supports .NET 7" {
+                let app =
+                    webApp {
+                        name "net7"
+                        runtime_stack Runtime.DotNet70
+                    }
+
+                let site = app |> getResources |> getResource<Web.Site> |> List.head
+                Expect.equal site.NetFrameworkVersion.Value "v7.0" "Wrong dotnet version"
+                Expect.equal site.Metadata.Head ("CURRENT_STACK", "dotnet") "Stack should be dotnet"
+            }
+
             test "Supports .NET 5 on Linux" {
                 let app =
                     webApp {


### PR DESCRIPTION
* Add support for setting .NET 7 as runtime stack.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
