### PR TITLE
Add missing service bus options

### DIFF
--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -13,7 +13,7 @@ let subscriptions =
 
 let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2017-04-01")
 let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2017-04-01")
-let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2017-04-01")
+let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2022-01-01-preview")
 
 let queueAuthorizationRules =
     ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2017-04-01")
@@ -213,6 +213,9 @@ type Namespace =
         Location: Location
         Sku: Sku
         Dependencies: ResourceId Set
+        ZoneRedundant: FeatureFlag
+        DisablePublicNetworkAccess: FeatureFlag
+        MinTlsVersion: TlsVersion option
         Tags: Map<string, string>
     }
 
@@ -234,5 +237,22 @@ type Namespace =
                         name = this.Sku.NameArmValue
                         tier = this.Sku.TierArmValue
                         capacity = this.Capacity |> Option.toNullable
+                    |}
+                properties =
+                    {|
+                        minimumTlsVersion =
+                            match this.MinTlsVersion with
+                            | Some Tls10 -> "1.0"
+                            | Some Tls11 -> "1.1"
+                            | Some Tls12 -> "1.2"
+                            | None -> null
+                        publicNetworkAccess = 
+                          match this.DisablePublicNetworkAccess with
+                          | FeatureFlag.Enabled -> "Disabled"
+                          | FeatureFlag.Disabled -> "Enabled"
+                        zoneRedundant = 
+                          match this.ZoneRedundant with
+                          | FeatureFlag.Enabled -> "true"
+                          | FeatureFlag.Disabled -> "false"
                     |}
             |}

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -9,21 +9,21 @@ let private tryGetIso (v: IsoDateTime option) =
     v |> Option.map (fun v -> v.Value) |> Option.toObj
 
 let subscriptions =
-    ResourceType("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2022-01-01-preview")
 
-let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2017-04-01")
-let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2017-04-01")
+let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2022-01-01-preview")
+let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2022-01-01-preview")
 let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2022-01-01-preview")
 
 let queueAuthorizationRules =
-    ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2022-01-01-preview")
 
 let namespaceAuthorizationRules =
-    ResourceType("Microsoft.ServiceBus/namespaces/AuthorizationRules", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/AuthorizationRules", "2022-01-01-preview")
 
 module Namespaces =
     module Topics =
-        let rules = ResourceType("Rules", "2017-04-01")
+        let rules = ResourceType("Rules", "2022-01-01-preview")
 
         type Subscription =
             {

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -464,6 +464,9 @@ type ServiceBusConfig =
         Queues: Map<ResourceName, ServiceBusQueueConfig>
         Topics: Map<ResourceName, ServiceBusTopicConfig>
         AuthorizationRules: Map<ResourceName, AuthorizationRuleRight Set>
+        ZoneRedundant: FeatureFlag
+        DisablePublicNetworkAccess: FeatureFlag
+        MinTlsVersion: TlsVersion option
         Tags: Map<string, string>
     }
 
@@ -488,6 +491,9 @@ type ServiceBusConfig =
                     Location = location
                     Sku = this.Sku
                     Dependencies = this.Dependencies
+                    DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
+                    ZoneRedundant = this.ZoneRedundant
+                    MinTlsVersion = this.MinTlsVersion
                     Tags = this.Tags
                 }
 
@@ -533,6 +539,9 @@ type ServiceBusBuilder() =
             Topics = Map.empty
             Dependencies = Set.empty
             AuthorizationRules = Map.empty
+            DisablePublicNetworkAccess = FeatureFlag.Disabled
+            ZoneRedundant = FeatureFlag.Disabled
+            MinTlsVersion = None
             Tags = Map.empty
         }
 
@@ -565,6 +574,25 @@ type ServiceBusBuilder() =
     /// The SKU of the namespace.
     [<CustomOperation "sku">]
     member _.Sku(state: ServiceBusConfig, sku) = { state with Sku = sku }
+
+    /// Enable zone redundancy
+    [<CustomOperation "enable_zone_redundancy">]
+    member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with ZoneRedundant = flag }
+
+    /// Disable public network access
+    [<CustomOperation "disable_public_network_access">]
+    member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with DisablePublicNetworkAccess = flag }
+
+    /// Set minimum TLS version
+    [<CustomOperation "min_tls_version">]
+    member _.SetMinTlsVersion(state: ServiceBusConfig, minTlsVersion:TlsVersion) =
+        { state with
+            MinTlsVersion = Some minTlsVersion
+        }
 
     [<CustomOperation "add_queues">]
     member _.AddQueues(state: ServiceBusConfig, queues) =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.9</Version>
+    <Version>1.7.10</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
@@ -26,6 +26,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/CompositionalIT/farmer</RepositoryUrl>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!-- SourceLink settings -->
     <IncludeSymbols>true</IncludeSymbols>
@@ -42,6 +43,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
+	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.10</Version>
+    <Version>1.7.9</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>
@@ -26,7 +26,6 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/CompositionalIT/farmer</RepositoryUrl>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!-- SourceLink settings -->
     <IncludeSymbols>true</IncludeSymbols>
@@ -43,10 +42,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
-	  <PackageReference Include="Codat.DevOps.NugetSupport" Version="1.3.4">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -320,6 +320,10 @@ let tests =
                         sku (ServiceBus.Sku.Premium MessagingUnits.OneUnit)
                         add_queues [ queue { name "queue1" } ]
 
+                        min_tls_version TlsVersion.Tls12
+                        enable_zone_redundancy
+                        disable_public_network_access
+
                         add_topics
                             [
                                 topic {

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -44,12 +44,18 @@ let dummyClient =
 let getResourceAtIndex o =
     o |> getResourceAtIndex dummyClient.SerializationSettings
 
+
+let parseTemplate (arm:ResourceGroupConfig) = 
+    let json = arm.Template |> Writer.toJson
+    Newtonsoft.Json.Linq.JObject.Parse(json)
+
+
 let tests =
     testList
         "Service Bus Tests"
         [
             test "Namespace is correctly created" {
-                let sbNs =
+                let resourceGroup =
                     arm {
                         add_resource (
                             serviceBus {
@@ -58,13 +64,17 @@ let tests =
                             }
                         )
                     }
-                    |> findAzureResources<SBNamespace> dummyClient.SerializationSettings
-                    |> List.head
+                    
+                let sbNs = resourceGroup |> findAzureResources<SBNamespace> dummyClient.SerializationSettings |> List.head
 
                 sbNs.Validate()
 
                 Expect.equal sbNs.Name "serviceBus" "Invalid namespace name"
                 Expect.equal sbNs.Sku.Name SkuName.Standard "Invalid Sku"
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString()) "false" "Service bus should not be zone redundant by default"
+                Expect.equal (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "Public network access should be enabled by default"
             }
 
             test "Namespace validation is respected" {
@@ -87,6 +97,89 @@ let tests =
                     (fun _ -> serviceBus { name "c347834e-3f04-409c-b26b-c5ed702dea0b" } |> ignore)
                     "Namespace is a guid"
             }
+
+            test "Public network access can be disabled" {
+                let resourceGroup =
+                    arm {
+                        add_resource (
+                            serviceBus {
+                                name "serviceBus"
+                                sku Standard
+                                disable_public_network_access
+                            }
+                        )
+                    }
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "Public network access should be disabled"
+            }
+
+            test "Public network access can be toggled" {
+                let resourceGroup =
+                    arm {
+                        add_resource (
+                            serviceBus {
+                                name "serviceBus"
+                                sku Standard
+                                disable_public_network_access
+                                disable_public_network_access FeatureFlag.Disabled
+                            }
+                        )
+                    }
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "Public network access should be enabled"
+            }
+
+            test "Zone redundancy can be enabled" {
+                let resourceGroup =
+                    arm {
+                        add_resource (
+                            serviceBus {
+                                name "serviceBus"
+                                sku Standard
+                                enable_zone_redundancy
+                            }
+                        )
+                    }
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString()) "true" "Zone redundancy should be enabled"
+            }
+            
+            test "Zone redundancy can be toggled" {
+                let resourceGroup =
+                    arm {
+                        add_resource (
+                            serviceBus {
+                                name "serviceBus"
+                                sku Standard
+                                enable_zone_redundancy
+                                enable_zone_redundancy FeatureFlag.Disabled
+                            }
+                        )
+                    }
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString()) "false" "Zone redundancy should be disabled"
+            }
+
+            test "Min TLS version can be set" {
+                let resourceGroup =
+                    arm {
+                        add_resource (
+                            serviceBus {
+                                name "serviceBus"
+                                sku Standard
+                                min_tls_version TlsVersion.Tls12
+                            }
+                        )
+                    }
+
+                let jobj = parseTemplate resourceGroup
+                Expect.equal (jobj.SelectToken($"resources[0].properties.minimumTlsVersion").ToString()) "1.2" "Min TLS should be 1.2"
+            }
+
 
             testList
                 "Queue Tests"

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -59,7 +59,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmereventpubservicebusns')]"
       ],

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -43,10 +43,14 @@
       "type": "Microsoft.Storage/storageAccounts/queueServices/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmereventpubservicebusns",
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "zoneRedundant": "false"
+      },
       "sku": {
         "name": "Basic",
         "tier": "Basic"

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -340,7 +340,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus1979')]"
       ],
@@ -349,7 +349,7 @@
       "type": "Microsoft.ServiceBus/namespaces/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus1979')]"
       ],
@@ -358,7 +358,7 @@
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmerbus1979', 'topic1')]"
       ],

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -324,10 +324,14 @@
       "type": "Microsoft.Web/sites"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmerbus1979",
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "zoneRedundant": "false"
+      },
       "sku": {
         "name": "Standard",
         "tier": "Standard"

--- a/src/Tests/test-data/service-bus.json
+++ b/src/Tests/test-data/service-bus.json
@@ -23,7 +23,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
@@ -32,7 +32,7 @@
       "type": "Microsoft.ServiceBus/namespaces/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
@@ -41,7 +41,7 @@
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'topic1')]"
       ],
@@ -49,7 +49,7 @@
       "properties": {},
       "resources": [
         {
-          "apiVersion": "2017-04-01",
+          "apiVersion": "2022-01-01-preview",
           "dependsOn": [
             "sub1"
           ],
@@ -68,14 +68,14 @@
       "type": "Microsoft.ServiceBus/namespaces/topics/subscriptions"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "name": "farmer-bus/unmanaged-topic",
       "properties": {},
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'unmanaged-topic')]"
       ],
@@ -83,7 +83,7 @@
       "properties": {},
       "resources": [
         {
-          "apiVersion": "2017-04-01",
+          "apiVersion": "2022-01-01-preview",
           "dependsOn": [
             "sub1"
           ],

--- a/src/Tests/test-data/service-bus.json
+++ b/src/Tests/test-data/service-bus.json
@@ -5,10 +5,15 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmer-bus",
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Disabled",
+        "zoneRedundant": "true"
+      },
       "sku": {
         "capacity": 1,
         "name": "Premium",


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add support for zone redundancy, disabling public network access, and setting the min TLS version.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myServiceBus = serviceBus {
  name "myServicebus"
  sku (Premium TwoUnits)
  
  add_queues [
      queue { name "test-queue" }
  ]

  disable_public_network_access
  enable_zone_redundancy
  min_tls_version TlsVersion.Tls12

  add_tags tags
}

```
