### PR TITLE
add disable_public_network_access to keyvault

### DIFF
--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -5,13 +5,13 @@ open Farmer
 open Farmer.KeyVault
 open System
 
-let secrets = ResourceType("Microsoft.KeyVault/vaults/secrets", "2019-09-01")
+let secrets = ResourceType("Microsoft.KeyVault/vaults/secrets", "2022-07-01")
 
 let accessPolicies =
-    ResourceType("Microsoft.KeyVault/vaults/accessPolicies", "2019-09-01")
+    ResourceType("Microsoft.KeyVault/vaults/accessPolicies", "2022-07-01")
 
-let vaults = ResourceType("Microsoft.KeyVault/vaults", "2019-09-01")
-let keys = ResourceType("Microsoft.keyVault/vaults/keys", "2019-09-01")
+let vaults = ResourceType("Microsoft.KeyVault/vaults", "2022-07-01")
+let keys = ResourceType("Microsoft.keyVault/vaults/keys", "2022-07-01")
 
 module Vaults =
     type Secret =

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -147,6 +147,7 @@ type Vault =
         Bypass: Bypass option
         IpRules: string list
         VnetRules: string list
+        DisablePublicNetworkAccess: FeatureFlag
         Tags: Map<string, string>
     }
 
@@ -215,6 +216,10 @@ type Vault =
                                 ipRules = this.IpRules
                                 virtualNetworkRules = this.VnetRules |> List.map (fun rule -> {| id = rule |})
                             |}
+                        publicNetworkAccess = 
+                          match this.DisablePublicNetworkAccess with
+                          | FeatureFlag.Enabled -> "Disabled"
+                          | FeatureFlag.Disabled -> "Enabled"
                     |}
             |}
 

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -191,6 +191,7 @@ type KeyVaultConfig =
         Uri: Uri option
         Keys: KeyConfig list
         Secrets: SecretConfig list
+        DisablePublicNetworkAccess: FeatureFlag
         Tags: Map<string, string>
     }
 
@@ -248,6 +249,7 @@ type KeyVaultConfig =
                         Bypass = this.NetworkAcl.Bypass
                         IpRules = this.NetworkAcl.IpRules
                         VnetRules = this.NetworkAcl.VnetRules
+                        DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
                         Tags = this.Tags
                     }
 
@@ -414,6 +416,7 @@ type KeyVaultBuilderState =
         Uri: Uri option
         Secrets: SecretConfig list
         Keys: KeyConfig list
+        DisablePublicNetworkAccess: FeatureFlag
         Tags: Map<string, string>
     }
 
@@ -443,6 +446,7 @@ type KeyVaultBuilder() =
             Uri = None
             Secrets = []
             Keys = []
+            DisablePublicNetworkAccess = FeatureFlag.Disabled
             Tags = Map.empty
         }
 
@@ -464,6 +468,7 @@ type KeyVaultBuilder() =
             Keys = state.Keys
             Secrets = state.Secrets
             Uri = state.Uri
+            DisablePublicNetworkAccess = state.DisablePublicNetworkAccess
             Tags = state.Tags
         }
 
@@ -711,6 +716,12 @@ type KeyVaultBuilder() =
 
     member this.AddSecrets(state: KeyVaultBuilderState, items) =
         this.AddSecrets(state, items |> Seq.map (fun (key, value) -> SecretConfig.create (key, value)))
+
+    /// Disable public network access
+    [<CustomOperation "disable_public_network_access">]
+    member _.DisablePublicNetworkAccess(state: KeyVaultBuilderState, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with DisablePublicNetworkAccess = flag }
 
     interface ITaggable<KeyVaultBuilderState> with
         member _.Add state tags =

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -338,4 +338,40 @@ let tests =
                 let ruleId = string rules.[0].["id"]
                 Expect.equal vnetId ruleId "The setup network rule should match the used vnetId"
             }
+            test "Public network access should be enabled by default" {
+                let vault =
+                    keyVault {
+                        name "TestFarmVault"
+                    }
+
+                let deployment = arm { add_resource vault }
+                let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
+
+                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "public network access should be enabled by default"
+            }
+            test "Public network access can be toggled" {
+                let vault =
+                    keyVault {
+                        name "TestFarmVault"
+                        disable_public_network_access
+                        disable_public_network_access FeatureFlag.Disabled
+                    }
+
+                let deployment = arm { add_resource vault }
+                let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
+
+                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "public network access should be enabled"
+            }
+            test "Public network access can be disabled" {
+                let vault =
+                    keyVault {
+                        name "TestFarmVault"
+                        disable_public_network_access
+                    }
+
+                let deployment = arm { add_resource vault }
+                let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
+
+                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "public network access should be disabled"
+            }
         ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add disable_public_network_access to key vault builder

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let vault = keyVault {
  name "keyvault"
  sku KeyVault.Sku.Standard
  tenant_id "blah"

  disable_public_network_access
}

```
