### PR TITLE
Cosmos - restrict_to_azure_services

### DIFF
--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -127,6 +127,7 @@ type DatabaseAccount =
         ConsistencyPolicy: ConsistencyPolicy
         FailoverPolicy: FailoverPolicy
         PublicNetworkAccess: FeatureFlag
+        RestrictToAzureServices: FeatureFlag
         FreeTier: bool
         Serverless: FeatureFlag
         Kind: DatabaseKind
@@ -215,6 +216,10 @@ type DatabaseAccount =
                             | [], Disabled -> null
                             | locations, _ -> box locations
                         publicNetworkAccess = string this.PublicNetworkAccess
+                        ipRules = 
+                          match this.RestrictToAzureServices with
+                          | Enabled -> box [ "0.0.0.0" ]
+                          | Disabled -> null
                         enableFreeTier = this.FreeTier
                         capabilities =
                             if this.Serverless = Enabled then

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -218,7 +218,13 @@ type DatabaseAccount =
                         publicNetworkAccess = string this.PublicNetworkAccess
                         ipRules = 
                           match this.RestrictToAzureServices with
-                          | Enabled -> box [ "0.0.0.0" ]
+                          | Enabled ->
+                                box
+                                    [
+                                        {|
+                                            ipAddressOrRange = "0.0.0.0"
+                                        |}
+                                    ]
                           | Disabled -> null
                         enableFreeTier = this.FreeTier
                         capabilities =

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -74,6 +74,7 @@ type CosmosDbConfig =
         DbThroughput: Throughput
         Containers: CosmosDbContainerConfig list
         PublicNetworkAccess: FeatureFlag
+        RestrictToAzureServices: FeatureFlag
         FreeTier: bool
         BackupPolicy: BackupPolicy
         Tags: Map<string, string>
@@ -123,6 +124,7 @@ type CosmosDbConfig =
                             | Serverless -> Enabled
                             | _ -> Disabled
                         PublicNetworkAccess = this.PublicNetworkAccess
+                        RestrictToAzureServices = this.RestrictToAzureServices
                         FailoverPolicy = this.AccountFailoverPolicy
                         FreeTier = this.FreeTier
                         BackupPolicy = this.BackupPolicy
@@ -246,6 +248,7 @@ type CosmosDbBuilder() =
             DbThroughput = Provisioned 400<RU>
             Containers = []
             PublicNetworkAccess = Enabled
+            RestrictToAzureServices = Disabled
             FreeTier = false
             BackupPolicy = BackupPolicy.NoBackup
             Tags = Map.empty
@@ -336,6 +339,13 @@ type CosmosDbBuilder() =
     member _.BackupPolicy(state: CosmosDbConfig, backupPolicy:BackupPolicy) =
         { state with
             BackupPolicy = backupPolicy
+        }
+
+    /// Add an IP rule which only allows access from Azure services.
+    [<CustomOperation "restrict_to_azure_services">]
+    member _.RestrictToAzureServices(state: CosmosDbConfig) =
+        { state with
+            RestrictToAzureServices = Enabled
         }
 
     /// Enables the use of CosmosDB free tier (one per subscription).

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -256,7 +256,7 @@ let tests =
                 let jobj = json |> Newtonsoft.Json.Linq.JObject.Parse
 
                 let resourcePrefix = "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts')].properties"
-                Expect.equal (jobj.SelectToken($"{resourcePrefix}.ipRules[0]").ToString()) "0.0.0.0" "IP rule for 0.0.0.0 should be added to restrict network access to Azure services"
+                Expect.equal (jobj.SelectToken($"{resourcePrefix}.ipRules[0].ipAddressOrRange").ToString()) "0.0.0.0" "IP rule for 0.0.0.0 should be added to restrict network access to Azure services"
             }
             testList
                 "Account Name Validation tests"

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -246,6 +246,18 @@ let tests =
                 let resourcePrefix = "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases')]"
                 Expect.equal (jobj.SelectToken($"{resourcePrefix}.properties.options.autoscaleSettings.maxThroughput").ToString()) "1000" "Max throughput should be 1000"
             }
+            test "Restrict to Azure services" {
+                let t = arm { add_resource (cosmosDb {
+                    name "test"
+                    restrict_to_azure_services
+                })}
+
+                let json = t.Template |> Writer.toJson 
+                let jobj = json |> Newtonsoft.Json.Linq.JObject.Parse
+
+                let resourcePrefix = "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts')].properties"
+                Expect.equal (jobj.SelectToken($"{resourcePrefix}.ipRules[0]").ToString()) "0.0.0.0" "IP rule for 0.0.0.0 should be added to restrict network access to Azure services"
+            }
             testList
                 "Account Name Validation tests"
                 [


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add `restrict_to_azure_services` which is required to add private endpoints without downtime.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
cosmosDb {
    name "test"

    // new
    restrict_to_azure_services
}
```
