### PR TITLE
Add support for dedicated container throughput

### DIFF
--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -33,6 +33,7 @@ module DatabaseAccounts =
                 IndexingPolicy: {| IncludedPaths: {| Path: string
                                                      Indexes: (IndexDataType * IndexKind) list |} list
                                    ExcludedPaths: string list |}
+                Throughput: Throughput option
             }
 
             interface IArmResource with
@@ -82,6 +83,21 @@ module DatabaseAccounts =
                                                     |> List.map (fun p -> {| path = p |})
                                             |}
                                     |}
+                                options = 
+                                    match this.Throughput with
+                                    | Some t -> 
+                                        box 
+                                            {|
+                                                throughput =
+                                                    match t with
+                                                    | Provisioned p -> string p
+                                                    | _ -> null
+                                                autoscaleSettings =
+                                                    match t with
+                                                    | Autoscale a -> box {| maxThroughput = string a |}
+                                                    | _ -> null
+                                            |}
+                                    | None -> null
                             |}
                     |}
 

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -105,7 +105,7 @@ module DatabaseAccounts =
         {
             Name: ResourceName
             Account: ResourceName
-            Throughput: Throughput
+            Throughput: Throughput option
             Kind: DatabaseKind
         }
 
@@ -123,16 +123,20 @@ module DatabaseAccounts =
                         {|
                             resource = {| id = this.Name.Value |}
                             options =
-                                {|
-                                    throughput =
-                                        match this.Throughput with
-                                        | Provisioned t -> string t
-                                        | _ -> null
-                                    autoscaleSettings =
-                                        match this.Throughput with
-                                        | Autoscale t -> box {| maxThroughput = string t |}
-                                        | _ -> null
-                                |}
+                                match this.Throughput with
+                                | Some t ->
+                                    box
+                                        {|
+                                            throughput =
+                                                match t with
+                                                | Provisioned t -> string t
+                                                | _ -> null
+                                            autoscaleSettings =
+                                                match t with
+                                                | Autoscale t -> box {| maxThroughput = string t |}
+                                                | _ -> null
+                                        |}
+                                | None -> null
                         |}
                 |}
 

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -133,9 +133,10 @@ type CosmosDbConfig =
                     }
                 | _ -> ()
 
-                // check if we're setting the throughput directly on the container
+                // When we have containers and they all have throughput set, do not set shared (database) throughput.
+                // When only some containers have throughput, set the shared throughput.
                 let dbThroughput =
-                  if this.Containers |> List.exists(fun x -> x.ContainerThroughput.IsSome) then
+                  if this.Containers.Length > 0 && this.Containers |> List.forall(fun x -> x.ContainerThroughput.IsSome) then
                     None
                   else
                     Some this.DbThroughput

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -63,6 +63,7 @@ type CosmosDbContainerConfig =
         Indexes: (string * (IndexDataType * IndexKind) list) list
         UniqueKeys: Set<string list>
         ExcludedPaths: string list
+        ContainerThroughput: Throughput option
     }
 
 type CosmosDbConfig =
@@ -166,6 +167,7 @@ type CosmosDbConfig =
                                             {| Path = path; Indexes = indexes |}
                                     ]
                             |}
+                        Throughput = container.ContainerThroughput
                     }
             ]
 
@@ -177,6 +179,7 @@ type CosmosDbContainerBuilder() =
             Indexes = []
             UniqueKeys = Set.empty
             ExcludedPaths = []
+            ContainerThroughput = None
         }
 
     member _.Run state =
@@ -226,6 +229,11 @@ type CosmosDbContainerBuilder() =
         { state with
             ExcludedPaths = path :: state.ExcludedPaths
         }
+
+    /// Sets the throughput of the container.
+    [<CustomOperation "throughput">]
+    member _.Throughput(state: CosmosDbContainerConfig, throughput) =
+        { state with ContainerThroughput = Some throughput }
 
 type CosmosDbBuilder() =
     member _.Yield _ =

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -133,11 +133,18 @@ type CosmosDbConfig =
                     }
                 | _ -> ()
 
+                // check if we're setting the throughput directly on the container
+                let dbThroughput =
+                  if this.Containers |> List.exists(fun x -> x.ContainerThroughput.IsSome) then
+                    None
+                  else
+                    Some this.DbThroughput
+
                 // Database
                 {
                     Name = this.DbName
                     Account = this.AccountResourceId.Name
-                    Throughput = this.DbThroughput
+                    Throughput = dbThroughput
                     Kind = this.Kind
                 }
 

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -235,6 +235,11 @@ type CosmosDbContainerBuilder() =
     member _.Throughput(state: CosmosDbContainerConfig, throughput) =
         { state with ContainerThroughput = Some throughput }
 
+    member _.Throughput(state: CosmosDbContainerConfig, throughput) =
+        { state with
+            ContainerThroughput = Some (Provisioned throughput)
+        }
+
 type CosmosDbBuilder() =
     member _.Yield _ =
         {

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -273,6 +273,9 @@ let tests =
                 let json = t.Template |> Writer.toJson 
                 let jobj = json |> Newtonsoft.Json.Linq.JObject.Parse
 
+                let found, _ = jobj.TryGetValue("$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases')].properties.options.throughput")
+                Expect.isFalse found "when container throughput is set database throughput should not be specified"
+
                 let resourcePrefix = "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers')]"
                 Expect.equal (jobj.SelectToken($"{resourcePrefix}.properties.options.throughput").ToString()) "100" "throughput should be 100"
             }
@@ -290,6 +293,9 @@ let tests =
 
                 let json = t.Template |> Writer.toJson 
                 let jobj = json |> Newtonsoft.Json.Linq.JObject.Parse
+
+                let found, _ = jobj.TryGetValue("$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases')].properties.options.throughput")
+                Expect.isFalse found "when container throughput is set database throughput should not be specified"
 
                 let resourcePrefix = "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers')]"
                 Expect.equal (jobj.SelectToken($"{resourcePrefix}.properties.options.autoscaleSettings.maxThroughput").ToString()) "1000" "Max throughput should be 1000"

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -265,7 +265,7 @@ let tests =
                         cosmosContainer {
                             name "SomeContainer"
                             partition_key [ "/id" ] CosmosDb.Hash
-                            throughput (CosmosDb.Throughput.Provisioned(100<CosmosDb.RU>))
+                            throughput 100<CosmosDb.RU>
                         }
                     ]
                 })}


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add support for dedicated container throughput 
* Mixed mode is allowed (see tests)

Relevant Azure [docs](https://learn.microsoft.com/en-us/azure/cosmos-db/set-throughput#set-throughput-on-a-database-and-a-container)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let t = arm { add_resource (cosmosDb {
    name "test"
    throughput 1000<CosmosDb.RU> // set the shared throughput
    add_containers [

        // no throughput specified - uses shared.
        cosmosContainer {
            name "IUseSharedThroughput"
            partition_key [ "/id" ] CosmosDb.Hash
        }

        // dedicated container throughput
        cosmosContainer {
            name "IUseDedicatedThroughput"
            partition_key [ "/id" ] CosmosDb.Hash
            throughput 100<CosmosDb.RU>
        }
    ]
})}

```
