### PR TITLE
Allow specification on NET Framework on slot for a webapp

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -72,6 +72,7 @@ type Runtime =
     static member DotNet50 = DotNet "5.0"
     static member DotNet60 = DotNet "6.0"
     static member DotNet70 = DotNet "7.0"
+    static member DotNet80 = DotNet "8.0"
     static member AspNet47 = AspNet "4.0"
     static member AspNet35 = AspNet "2.0"
     static member Python27 = Python("2.7", "2.7")
@@ -110,6 +111,7 @@ type SlotConfig =
         ApplyIPSecurityRestrictionsToScm: bool
         EnablePublicNetworkAccess: bool option
         AlwaysOn: bool option
+        NetFrameworkVersion: string option
     }
 
     member this.ToSite(owner: Arm.Web.Site) =
@@ -137,6 +139,7 @@ type SlotConfig =
             ApplyIPSecurityRestrictionsToScm = this.ApplyIPSecurityRestrictionsToScm
             EnablePublicNetworkAccess = this.EnablePublicNetworkAccess
             ZipDeployPath = None
+            NetFrameworkVersion = this.NetFrameworkVersion 
             PostDeployActions =
                 [
                     fun rg ->
@@ -217,6 +220,7 @@ type SlotBuilder() =
             IpSecurityRestrictions = []
             ApplyIPSecurityRestrictionsToScm = false
             EnablePublicNetworkAccess = None
+            NetFrameworkVersion = None 
             AlwaysOn = None
         }
 
@@ -368,6 +372,15 @@ type SlotBuilder() =
     member _.EnablePublicNetworkAccess(state) : SlotConfig =
         { state with 
             EnablePublicNetworkAccess = Some true
+        }
+        
+    [<CustomOperation "runtime">]
+    member this.Runtime(state: SlotConfig, runtime : Runtime) =
+        { state with NetFrameworkVersion =  match runtime with
+                                                | AspNet version
+                                                | DotNet ("5.0" as version)
+                                                | DotNet version -> Some $"v{version}"
+                                                | _ -> None
         }
 
     interface ITaggable<SlotConfig> with

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -373,7 +373,8 @@ type SlotBuilder() =
         { state with 
             EnablePublicNetworkAccess = Some true
         }
-        
+    
+    /// Adds Runtime to the slot, to allow zero downtime deployments when changing runtime.
     [<CustomOperation "runtime">]
     member this.Runtime(state: SlotConfig, runtime : Runtime) =
         { state with NetFrameworkVersion =  match runtime with

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -2098,9 +2098,9 @@ let tests =
                 // Default "production" slot is not included as it is created automatically in Azure
                 Expect.hasLength slots 1 "Should only be 1 slot"
 
-                let connStrings =
+                let netFrameworkVersion =
                  Expect.wantSome slots[0].NetFrameworkVersion "Net Framework version should be set"
 
-                Expect.equal connStrings "v8.0" "Net Framework version should be set to 8.0"
+                Expect.equal netFrameworkVersion "v8.0" "Net Framework version should be set to 8.0"
             }
         ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -2075,4 +2075,32 @@ let tests =
                 Expect.equal slot.Name.Value "webapp/deployment" "Slot name was not as expected"
                 Expect.equal slot.AlwaysOn false "Slot was not set to Always On -> false"
             }
+            test "WebApp supports runtime on slot" {
+                let slot =
+                    appSlot {
+                        name "warm-up"
+                        runtime Runtime.DotNet80
+                    }
+
+                let app =
+                    webApp {
+                        name "webapp"
+                        add_slot slot
+                    }
+
+                Expect.isTrue (app.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
+
+                let slots =
+                    app
+                    |> getResources
+                    |> getResource<Arm.Web.Site>
+                    |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
+                // Default "production" slot is not included as it is created automatically in Azure
+                Expect.hasLength slots 1 "Should only be 1 slot"
+
+                let connStrings =
+                 Expect.wantSome slots[0].NetFrameworkVersion "Net Framework version should be set"
+
+                Expect.equal connStrings "v8.0" "Net Framework version should be set to 8.0"
+            }
         ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Allows specification of NET Framework for a web app slot
* Adds .NET 8 member to Runtime

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let slot =
  appSlot {
      name "warm-up"
      runtime Runtime.DotNet80
  }
```
