### PR TITLE
Add Linux runtime on a web app slot

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -143,7 +143,21 @@ type SlotConfig =
                                                                 |AspNet version
                                                                 | DotNet ("5.0" as version)
                                                                 | DotNet version -> Some $"v{version}"
-                                                                | _ -> None) |> Option.defaultValue owner.NetFrameworkVersion             
+                                                                | _ -> None) |> Option.defaultValue owner.NetFrameworkVersion
+            LinuxFxVersion = match owner.LinuxFxVersion with
+                                | None -> None
+                                | Some target ->
+                                    this.Runtime |> Option.map (fun r -> r |> function
+                                        | DotNetCore version -> Some $"DOTNETCORE|{version}"
+                                        | DotNet version -> Some $"DOTNETCORE|{version}"
+                                        | Node version -> Some $"NODE|{version}"
+                                        | Php version -> Some $"PHP|{version}"
+                                        | Ruby version -> Some $"RUBY|{version}"
+                                        | Java (runtime, JavaSE) -> Some $"JAVA|{runtime.Version}-{runtime.Jre}"
+                                        | Java (runtime, (Tomcat version)) -> Some $"TOMCAT|{version}-{runtime.Jre}"
+                                        | Java (Java8, WildFly14) -> Some $"WILDFLY|14-{Java8.Jre}"
+                                        | Python (linuxVersion, _) -> Some $"PYTHON|{linuxVersion}"
+                                        | _ -> None) |> Option.defaultValue owner.LinuxFxVersion
             PostDeployActions =
                 [
                     fun rg ->

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -2075,7 +2075,7 @@ let tests =
                 Expect.equal slot.Name.Value "webapp/deployment" "Slot name was not as expected"
                 Expect.equal slot.AlwaysOn false "Slot was not set to Always On -> false"
             }
-            test "WebApp supports runtime on slot" {
+            test "WebApp supports network framework runtime on slot" {
                 let slot =
                     appSlot {
                         name "warm-up"
@@ -2102,5 +2102,34 @@ let tests =
                  Expect.wantSome slots[0].NetFrameworkVersion "Net Framework version should be set"
 
                 Expect.equal netFrameworkVersion "v8.0" "Net Framework version should be set to 8.0"
+            }
+            test "WebApp supports runtime on a linux slot" {
+                let slot =
+                    appSlot {
+                        name "warm-up"
+                        runtime Runtime.DotNet80
+                    }
+
+                let app =
+                    webApp {
+                        name "webapp"
+                        operating_system Linux
+                        add_slot slot
+                    }
+
+                Expect.isTrue (app.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
+
+                let slots =
+                    app
+                    |> getResources
+                    |> getResource<Arm.Web.Site>
+                    |> List.filter (fun x -> x.ResourceType = Arm.Web.slots)
+                // Default "production" slot is not included as it is created automatically in Azure
+                Expect.hasLength slots 1 "Should only be 1 slot"
+
+                let linuxFxVersion =
+                 Expect.wantSome slots[0].LinuxFxVersion "Linux FX version should be set"
+
+                Expect.equal linuxFxVersion "DOTNETCORE|8.0" "Linux FX version should be set to 8.0"
             }
         ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add ability to specify Linux FX version on a slot for a web app

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let slot =
      appSlot {
          name "warm-up"
          runtime Runtime.DotNet80
      }
```
