### PR TITLE
Add taggability for SQL Databases

### DIFF
--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -134,6 +134,7 @@ module Servers =
             MaxSizeBytes: int64 option
             Sku: DbKind
             Collation: string
+            Tags: Map<string, string>
         }
 
         interface IArmResource with
@@ -160,7 +161,7 @@ module Servers =
                        serverName.ResourceName / this.Name,
                        this.Location,
                        dependsOn,
-                       tags = Map [ "displayName", this.Name.Value ]
+                       tags = this.Tags.Add("displayName", this.Name.Value)
                    ) with
                     sku =
                         match this.Sku with

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -343,4 +343,17 @@ let tests =
                 Expect.equal model.ElasticPoolId expectedPoolId "Incorrect pool name"
                 Expect.equal model.Name "server/db" "Incorrect database name"
             }
+
+            test "Can set tags on a DB" {
+                let sql =
+                    sqlDb {
+                        name "db"
+                        link_to_unmanaged_server (Arm.Sql.servers.resourceId("server")) (ResourceName "server-pool")
+                        add_tags [ "key", "value" ]
+                    }
+
+                let model: Models.Database = sql |> getResourceAtIndex client.SerializationSettings 0
+                let expectedTags = dict[ "key", "value" ]
+                Expect.containsAll model.Tags expectedTags "Tags missing"
+            }
         ]


### PR DESCRIPTION
The changes in this PR are as follows:
* Add taggability for SQL Databases

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
sqlDb {
    name "db"
    link_to_unmanaged_server (Arm.Sql.servers.resourceId("server")) (ResourceName "server-pool")
    add_tags [ "key", "value" ]
}
```
